### PR TITLE
Add projects & steps with reminders, calendar/dashboard revamp, DB v14 migration and CI test

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -25,14 +25,14 @@ jobs:
           channel: 'stable'
           cache: true
 
-      - name: Criar projeto Flutter base
-        run: flutter create .
-
       - name: Instalar dependências
         run: flutter pub get
 
       - name: Analisar projeto
         run: flutter analyze
+
+      - name: Executar testes
+        run: flutter test
 
       - name: Construir APK (Debug)
         run: flutter build apk --debug
@@ -40,5 +40,5 @@ jobs:
       - name: Fazer upload do APK
         uses: actions/upload-artifact@v4
         with:
-          name: DiasOrganize-debug-apk
+          name: DiasOrganize-v2-debug-apk
           path: build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -25,13 +25,13 @@ jobs:
           channel: 'stable'
           cache: true
 
-      - name: Instalar dependências
-        run: flutter pub get
-
       - name: Analisar projeto
         run: flutter analyze
 
       - name: Executar testes
+        run: flutter test
+
+          name: DiasOrganize-v2-debug-apk
         run: flutter test
 
       - name: Construir APK (Debug)

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@
 **/ios/Pods/
 
 node_modules/
+
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@
 **/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Pods/
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -156,3 +156,116 @@ test/                 # Testes automatizados
 - O funcionamento principal não depende de internet.
 - Dados são gravados localmente no dispositivo.
 - Recursos de organização, acompanhamento e cálculos continuam disponíveis offline.
+- Cálculo de saldo previsto e saldo realizado.
+- Controle por mês para visão consolidada.
+
+## Módulo de Dívidas
+
+- Cadastro de dívidas com valor total, credor e observações.
+- Geração automática de parcelas no financeiro.
+- Acompanhamento de parcelas pagas, pendentes e atrasadas.
+- Cálculo de valor restante e progresso de quitação.
+
+## Módulo de Projetos
+
+- Cadastro de projetos com prioridade, cor, ícone e prazo.
+- Criação de etapas (steps) por projeto.
+- Vínculo de tarefas com projeto/etapa.
+- Cálculo de progresso por tarefas ou por etapas.
+- Identificação de projetos atrasados e próximos do prazo.
+
+---
+
+## Como rodar localmente
+
+Pré-requisitos:
+- Flutter SDK (stable)
+- Android SDK (ou emulador/dispositivo Android)
+
+Passos:
+
+```bash
+flutter pub get
+flutter run
+```
+
+---
+
+## Como gerar APK localmente
+
+```bash
+flutter pub get
+flutter analyze
+flutter test
+flutter build apk --debug
+```
+
+APK gerado em:
+
+`build/app/outputs/flutter-apk/app-debug.apk`
+
+---
+
+## Como gerar APK pelo GitHub Actions
+
+O workflow já está configurado em `.github/workflows/build-apk.yml` para:
+
+1. Rodar em `push` na `main`.
+2. Rodar manualmente com `workflow_dispatch`.
+3. Executar `flutter pub get`.
+4. Executar `flutter analyze`.
+5. Executar `flutter test`.
+6. Gerar `flutter build apk --debug`.
+7. Publicar artifact.
+
+---
+
+## Como baixar o artifact
+
+1. Acesse a aba **Actions** do repositório no GitHub.
+2. Abra o workflow **Build DiasOrganize APK**.
+3. Selecione uma execução concluída com sucesso.
+4. Na seção **Artifacts**, baixe o arquivo:
+   - `DiasOrganize-v2-debug-apk`
+
+---
+
+## Estrutura do projeto
+
+```text
+lib/
+  app/                # Tema e configurações visuais globais
+  core/               # Serviços centrais (ex.: notificações)
+  data/
+    database/         # SQLite helper, criação e migrações
+    models/           # Modelos de domínio
+  domain/             # Providers e regras de estado
+  features/           # Módulos de UI (tasks, finance, debts, projects, etc.)
+test/                 # Testes automatizados
+.github/workflows/    # Pipeline CI para validação e build APK
+```
+
+---
+
+## Tecnologias usadas
+
+- Flutter
+- Dart
+- Riverpod
+- SQLite (`sqflite`)
+- Flutter Local Notifications
+- GitHub Actions
+
+---
+
+## Observações sobre banco local
+
+- O app utiliza SQLite local.
+- A versão atual do banco foi evoluída com migrações para suportar módulos de finanças, dívidas, projetos e etapas.
+- Migrações preservam dados antigos sempre que possível.
+
+## Observações sobre offline-first
+
+- O funcionamento principal não depende de internet.
+- Dados são gravados localmente no dispositivo.
+- Recursos de organização, acompanhamento e cálculos continuam disponíveis offline.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,158 @@
 # DiasOrganize
 
-Aplicativo focado em organização pessoal offline-first feito em Flutter e Dart.
+Aplicativo de organização pessoal **offline-first** desenvolvido com Flutter, com foco em produtividade, controle financeiro, dívidas e planejamento de projetos em um único app.
 
-## Como gerar o APK via GitHub Actions
+---
 
-Este repositório conta com integração contínua (CI) usando **GitHub Actions**. O APK é gerado automaticamente a cada push na branch principal (`main`).
+## Descrição geral
 
-1. Envie (Push) este repositório para a sua conta no GitHub.
-2. Acesse a aba **Actions** no seu repositório do GitHub.
-3. Clique no workflow **Build DiasOrganize APK**.
-4. Lá constarão as execuções. Selecione a mais recente com check verde.
-5. Role a página da execução selecionada até o fim, na seção **Artifacts**.
-6. Conclua o download do arquivo `DiasOrganize-debug-apk` e instale no seu dispositivo Android.
+O DiasOrganize foi criado para centralizar o dia a dia pessoal: tarefas, compromissos, finanças, dívidas e projetos, mantendo os dados localmente em SQLite e funcionando mesmo sem internet.
 
-## Como compilar localmente
+---
 
-Para compilar, você precisa ter o Flutter instalado e configurado em seu computador.
+## Funcionalidades da versão 1.0
 
-1. Baixe este código fonte.
-2. Abra o terminal na pasta raiz do projeto.
-3. O projeto precisa de algumas configurações nativas do Flutter que não sobem no git para ficar mais limpo. Por isso, gere a base executando:
-   ```bash
-   flutter create .
-   ```
-4. Baixe as bibliotecas necessárias:
-   ```bash
-   flutter pub get
-   ```
-5. Com um emulador ou dispositivo Android conectado, rode o projeto:
-   ```bash
-   flutter run
-   ```
-6. Para gerar um apk manualmente:
-   ```bash
-   flutter build apk --debug
-   ```
+- Gestão de tarefas com prioridades e status.
+- Categorias para organização de tarefas.
+- Calendário com visão de itens por data.
+- Estatísticas básicas de produtividade.
+- Tema claro e escuro.
+- Lembretes locais.
+- Persistência local com SQLite.
 
-## Funcionalidades
-- Gerenciamento completo de tarefas offline
-- Estatísticas de engajamento
-- Calendário de entregas
-- Categorias personalizadas
-- Tema claro e tema escuro
-- Lembretes locais
+---
+
+## Novidades da versão 2.0
+
+- Controle financeiro.
+- Receitas e despesas.
+- Categorias financeiras.
+- Controle de dívidas.
+- Parcelas.
+- Projetos pessoais.
+- Etapas de projetos.
+- Vínculo entre projetos e tarefas.
+- Dashboard expandido.
+- Estatísticas avançadas.
+- Calendário integrado.
+
+---
+
+## Módulo de Finanças
+
+- Cadastro de receitas e despesas.
+- Status de movimentações (pendente, pago, vencido, cancelado).
+- Categorias financeiras (receita/despesa/misto).
+- Cálculo de saldo previsto e saldo realizado.
+- Controle por mês para visão consolidada.
+
+## Módulo de Dívidas
+
+- Cadastro de dívidas com valor total, credor e observações.
+- Geração automática de parcelas no financeiro.
+- Acompanhamento de parcelas pagas, pendentes e atrasadas.
+- Cálculo de valor restante e progresso de quitação.
+
+## Módulo de Projetos
+
+- Cadastro de projetos com prioridade, cor, ícone e prazo.
+- Criação de etapas (steps) por projeto.
+- Vínculo de tarefas com projeto/etapa.
+- Cálculo de progresso por tarefas ou por etapas.
+- Identificação de projetos atrasados e próximos do prazo.
+
+---
+
+## Como rodar localmente
+
+Pré-requisitos:
+- Flutter SDK (stable)
+- Android SDK (ou emulador/dispositivo Android)
+
+Passos:
+
+```bash
+flutter pub get
+flutter run
+```
+
+---
+
+## Como gerar APK localmente
+
+```bash
+flutter pub get
+flutter analyze
+flutter test
+flutter build apk --debug
+```
+
+APK gerado em:
+
+`build/app/outputs/flutter-apk/app-debug.apk`
+
+---
+
+## Como gerar APK pelo GitHub Actions
+
+O workflow já está configurado em `.github/workflows/build-apk.yml` para:
+
+1. Rodar em `push` na `main`.
+2. Rodar manualmente com `workflow_dispatch`.
+3. Executar `flutter pub get`.
+4. Executar `flutter analyze`.
+5. Executar `flutter test`.
+6. Gerar `flutter build apk --debug`.
+7. Publicar artifact.
+
+---
+
+## Como baixar o artifact
+
+1. Acesse a aba **Actions** do repositório no GitHub.
+2. Abra o workflow **Build DiasOrganize APK**.
+3. Selecione uma execução concluída com sucesso.
+4. Na seção **Artifacts**, baixe o arquivo:
+   - `DiasOrganize-v2-debug-apk`
+
+---
+
+## Estrutura do projeto
+
+```text
+lib/
+  app/                # Tema e configurações visuais globais
+  core/               # Serviços centrais (ex.: notificações)
+  data/
+    database/         # SQLite helper, criação e migrações
+    models/           # Modelos de domínio
+  domain/             # Providers e regras de estado
+  features/           # Módulos de UI (tasks, finance, debts, projects, etc.)
+test/                 # Testes automatizados
+.github/workflows/    # Pipeline CI para validação e build APK
+```
+
+---
+
+## Tecnologias usadas
+
+- Flutter
+- Dart
+- Riverpod
+- SQLite (`sqflite`)
+- Flutter Local Notifications
+- GitHub Actions
+
+---
+
+## Observações sobre banco local
+
+- O app utiliza SQLite local.
+- A versão atual do banco foi evoluída com migrações para suportar módulos de finanças, dívidas, projetos e etapas.
+- Migrações preservam dados antigos sempre que possível.
+
+## Observações sobre offline-first
+
+- O funcionamento principal não depende de internet.
+- Dados são gravados localmente no dispositivo.
+- Recursos de organização, acompanhamento e cálculos continuam disponíveis offline.

--- a/lib/core/notifications/notification_service.dart
+++ b/lib/core/notifications/notification_service.dart
@@ -48,6 +48,10 @@ class NotificationService {
   int projectReminderId(int projectId) => 200000 + projectId;
   int projectStepReminderId(int stepId) => 300000 + stepId;
 
+  int transactionReminderId(int transactionId) => 100000 + transactionId;
+  int projectReminderId(int projectId) => 200000 + projectId;
+  int projectStepReminderId(int stepId) => 300000 + stepId;
+
   Future<void> cancelNotification(int id) async {
     await flutterLocalNotificationsPlugin.cancel(id);
   }

--- a/lib/core/notifications/notification_service.dart
+++ b/lib/core/notifications/notification_service.dart
@@ -44,6 +44,10 @@ class NotificationService {
     );
   }
 
+  int transactionReminderId(int transactionId) => 100000 + transactionId;
+  int projectReminderId(int projectId) => 200000 + projectId;
+  int projectStepReminderId(int stepId) => 300000 + stepId;
+
   Future<void> cancelNotification(int id) async {
     await flutterLocalNotificationsPlugin.cancel(id);
   }

--- a/lib/data/database/db_helper.dart
+++ b/lib/data/database/db_helper.dart
@@ -5,8 +5,9 @@ import '../models/category_model.dart';
 import '../models/setting_model.dart';
 import '../models/transaction_model.dart';
 import '../models/project_step_model.dart';
+    _database = await _initDB('diasorganize_v14.db');
 
-class DatabaseHelper {
+      version: 14,
   static final DatabaseHelper instance = DatabaseHelper._init();
   static Database? _database;
 
@@ -111,7 +112,93 @@ class DatabaseHelper {
         ''');
         await db.execute('ALTER TABLE transactions ADD COLUMN debtId INTEGER');
         await db.execute('ALTER TABLE transactions ADD COLUMN installmentNumber INTEGER');
-        await db.execute('ALTER TABLE transactions ADD COLUMN totalInstallments INTEGER');
+    if (oldVersion < 9) {
+      await db.execute('ALTER TABLE projects ADD COLUMN priority TEXT NOT NULL DEFAULT "media"');
+      await db.execute('ALTER TABLE projects ADD COLUMN color TEXT NOT NULL DEFAULT "0xFF2196F3"');
+      await db.execute('ALTER TABLE projects ADD COLUMN icon TEXT NOT NULL DEFAULT "rocket_launch"');
+      await db.execute('''
+        CREATE TABLE IF NOT EXISTS project_stages (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          projectId INTEGER NOT NULL,
+          title TEXT NOT NULL,
+          stageOrder INTEGER NOT NULL DEFAULT 0,
+          createdAt TEXT NOT NULL
+        )
+      ''');
+    }
+    if (oldVersion < 10) {
+      await db.execute('''
+        CREATE TABLE IF NOT EXISTS project_steps (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          projectId INTEGER NOT NULL,
+          title TEXT NOT NULL,
+          description TEXT,
+          orderIndex INTEGER NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'pending',
+          dueDate TEXT,
+          completedAt TEXT,
+          createdAt TEXT NOT NULL,
+          updatedAt TEXT NOT NULL
+        )
+      ''');
+      try {
+        final oldRows = await db.query('project_stages', orderBy: 'stageOrder ASC, id ASC');
+        for (final row in oldRows) {
+          await db.insert('project_steps', {
+            'projectId': row['projectId'],
+            'title': row['title'],
+            'description': null,
+            'orderIndex': row['stageOrder'] ?? 0,
+            'status': 'pending',
+            'dueDate': null,
+            'completedAt': null,
+            'createdAt': row['createdAt'],
+            'updatedAt': row['createdAt'],
+          });
+        }
+      } catch (_) {}
+    }
+    if (oldVersion < 11) {
+      await db.execute('ALTER TABLE tasks ADD COLUMN projectStepId INTEGER');
+    }
+    if (oldVersion < 12) {
+      await db.execute('ALTER TABLE projects ADD COLUMN notes TEXT');
+      await db.execute('ALTER TABLE projects ADD COLUMN completedAt TEXT');
+    }
+    if (oldVersion < 13) {
+      await db.execute('ALTER TABLE projects ADD COLUMN progress REAL NOT NULL DEFAULT 0');
+    }
+    if (oldVersion < 14) {
+      await db.execute('ALTER TABLE transactions ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE projects ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE project_steps ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0');
+    }
+        projectStepId INTEGER,
+        FOREIGN KEY (projectId) REFERENCES projects (id),
+        FOREIGN KEY (projectStepId) REFERENCES project_steps (id)
+        notes TEXT,
+        completedAt TEXT,
+        progress REAL NOT NULL DEFAULT 0,
+        reminderEnabled INTEGER NOT NULL DEFAULT 0,
+        priority TEXT NOT NULL DEFAULT 'media',
+        color TEXT NOT NULL DEFAULT '0xFF2196F3',
+        icon TEXT NOT NULL DEFAULT 'rocket_launch',
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE project_steps (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        projectId INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        orderIndex INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'pending',
+        dueDate TEXT,
+        completedAt TEXT,
+        reminderEnabled INTEGER NOT NULL DEFAULT 0,
+        reminderEnabled INTEGER NOT NULL DEFAULT 0,
       }
       if (oldVersion < 7) {
         // v7 migrations
@@ -396,9 +483,53 @@ class DatabaseHelper {
   Future<void> saveSetting(AppSetting setting) async {
     final db = await instance.database;
     final existing = await getSetting(setting.key);
-    if (existing != null) {
-      await db.update('settings', setting.toMap(), where: 'key = ?', whereArgs: [setting.key]);
+  Future<int> deleteProject(int id, {bool deleteLinkedTasks = false}) async {
+    if (deleteLinkedTasks) {
+      await db.delete('tasks', where: 'projectId = ?', whereArgs: [id]);
     } else {
+      await db.update('tasks', {'projectId': null, 'projectStepId': null}, where: 'projectId = ?', whereArgs: [id]);
+    }
+    await db.delete('project_steps', where: 'projectId = ?', whereArgs: [id]);
+    await db.delete('project_stages', where: 'projectId = ?', whereArgs: [id]);
+  Future<List<ProjectStep>> getProjectSteps(int projectId) async {
+    final db = await instance.database;
+    final result = await db.query('project_steps', where: 'projectId = ?', whereArgs: [projectId], orderBy: 'orderIndex ASC, id ASC');
+    return result.map((e) => ProjectStep.fromMap(e)).toList();
+  }
+
+  Future<List<ProjectStep>> getAllProjectSteps() async {
+    final db = await instance.database;
+    final result = await db.query('project_steps', orderBy: 'projectId ASC, orderIndex ASC, id ASC');
+    return result.map((e) => ProjectStep.fromMap(e)).toList();
+  }
+
+  Future<ProjectStep> createProjectStep(ProjectStep step) async {
+    final db = await instance.database;
+    final id = await db.insert('project_steps', step.toMap());
+    return ProjectStep(
+      id: id,
+      projectId: step.projectId,
+      title: step.title,
+      description: step.description,
+      orderIndex: step.orderIndex,
+      status: step.status,
+      dueDate: step.dueDate,
+      completedAt: step.completedAt,
+      createdAt: step.createdAt,
+      updatedAt: step.updatedAt,
+    );
+  }
+
+  Future<int> updateProjectStep(ProjectStep step) async {
+    final db = await instance.database;
+    return db.update('project_steps', step.toMap(), where: 'id = ?', whereArgs: [step.id]);
+  }
+
+  Future<int> deleteProjectStep(int id) async {
+    final db = await instance.database;
+    return db.delete('project_steps', where: 'id = ?', whereArgs: [id]);
+  }
+}
       await db.insert('settings', setting.toMap());
     }
   }

--- a/lib/data/database/db_helper.dart
+++ b/lib/data/database/db_helper.dart
@@ -4,6 +4,7 @@ import '../models/task_model.dart';
 import '../models/category_model.dart';
 import '../models/setting_model.dart';
 import '../models/transaction_model.dart';
+import '../models/project_step_model.dart';
 
 class DatabaseHelper {
   static final DatabaseHelper instance = DatabaseHelper._init();
@@ -13,7 +14,7 @@ class DatabaseHelper {
 
   Future<Database> get database async {
     if (_database != null) return _database!;
-    _database = await _initDB('diasorganize_v7.db');
+    _database = await _initDB('diasorganize_v14.db');
     return _database!;
   }
 
@@ -23,7 +24,7 @@ class DatabaseHelper {
 
     return await openDatabase(
       path, 
-      version: 8, 
+      version: 14,
       onCreate: _createDB,
       onUpgrade: _onUpgrade,
     );
@@ -136,6 +137,67 @@ class DatabaseHelper {
         await db.execute('ALTER TABLE tasks ADD COLUMN projectId INTEGER');
       }
     }
+    if (oldVersion < 9) {
+      await db.execute('ALTER TABLE projects ADD COLUMN priority TEXT NOT NULL DEFAULT "media"');
+      await db.execute('ALTER TABLE projects ADD COLUMN color TEXT NOT NULL DEFAULT "0xFF2196F3"');
+      await db.execute('ALTER TABLE projects ADD COLUMN icon TEXT NOT NULL DEFAULT "rocket_launch"');
+      await db.execute('''
+        CREATE TABLE IF NOT EXISTS project_stages (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          projectId INTEGER NOT NULL,
+          title TEXT NOT NULL,
+          stageOrder INTEGER NOT NULL DEFAULT 0,
+          createdAt TEXT NOT NULL
+        )
+      ''');
+    }
+    if (oldVersion < 10) {
+      await db.execute('''
+        CREATE TABLE IF NOT EXISTS project_steps (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          projectId INTEGER NOT NULL,
+          title TEXT NOT NULL,
+          description TEXT,
+          orderIndex INTEGER NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'pending',
+          dueDate TEXT,
+          completedAt TEXT,
+          createdAt TEXT NOT NULL,
+          updatedAt TEXT NOT NULL
+        )
+      ''');
+      try {
+        final oldRows = await db.query('project_stages', orderBy: 'stageOrder ASC, id ASC');
+        for (final row in oldRows) {
+          await db.insert('project_steps', {
+            'projectId': row['projectId'],
+            'title': row['title'],
+            'description': null,
+            'orderIndex': row['stageOrder'] ?? 0,
+            'status': 'pending',
+            'dueDate': null,
+            'completedAt': null,
+            'createdAt': row['createdAt'],
+            'updatedAt': row['createdAt'],
+          });
+        }
+      } catch (_) {}
+    }
+    if (oldVersion < 11) {
+      await db.execute('ALTER TABLE tasks ADD COLUMN projectStepId INTEGER');
+    }
+    if (oldVersion < 12) {
+      await db.execute('ALTER TABLE projects ADD COLUMN notes TEXT');
+      await db.execute('ALTER TABLE projects ADD COLUMN completedAt TEXT');
+    }
+    if (oldVersion < 13) {
+      await db.execute('ALTER TABLE projects ADD COLUMN progress REAL NOT NULL DEFAULT 0');
+    }
+    if (oldVersion < 14) {
+      await db.execute('ALTER TABLE transactions ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE projects ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE project_steps ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0');
+    }
   }
 
   Future _createDB(Database db, int version) async {
@@ -156,6 +218,7 @@ class DatabaseHelper {
         description TEXT,
         categoryId INTEGER,
         projectId INTEGER,
+        projectStepId INTEGER,
         priority TEXT NOT NULL,
         date TEXT,
         time TEXT,
@@ -164,7 +227,8 @@ class DatabaseHelper {
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL,
         FOREIGN KEY (categoryId) REFERENCES categories (id),
-        FOREIGN KEY (projectId) REFERENCES projects (id)
+        FOREIGN KEY (projectId) REFERENCES projects (id),
+        FOREIGN KEY (projectStepId) REFERENCES project_steps (id)
       )
     ''');
 
@@ -176,6 +240,28 @@ class DatabaseHelper {
         startDate TEXT,
         endDate TEXT,
         status TEXT NOT NULL,
+        notes TEXT,
+        completedAt TEXT,
+        progress REAL NOT NULL DEFAULT 0,
+        reminderEnabled INTEGER NOT NULL DEFAULT 0,
+        priority TEXT NOT NULL DEFAULT 'media',
+        color TEXT NOT NULL DEFAULT '0xFF2196F3',
+        icon TEXT NOT NULL DEFAULT 'rocket_launch',
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE project_steps (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        projectId INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        orderIndex INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'pending',
+        dueDate TEXT,
+        completedAt TEXT,
+        reminderEnabled INTEGER NOT NULL DEFAULT 0,
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL
       )
@@ -202,6 +288,7 @@ class DatabaseHelper {
         categoryId INTEGER,
         paymentMethod TEXT,
         status TEXT NOT NULL,
+        reminderEnabled INTEGER NOT NULL DEFAULT 0,
         isFixed INTEGER NOT NULL DEFAULT 0,
         recurrenceType TEXT NOT NULL,
         notes TEXT,
@@ -421,10 +508,54 @@ class DatabaseHelper {
     );
   }
 
-  Future<int> deleteProject(int id) async {
+  Future<int> deleteProject(int id, {bool deleteLinkedTasks = false}) async {
     final db = await instance.database;
-    await db.update('tasks', {'projectId': null}, where: 'projectId = ?', whereArgs: [id]);
+    if (deleteLinkedTasks) {
+      await db.delete('tasks', where: 'projectId = ?', whereArgs: [id]);
+    } else {
+      await db.update('tasks', {'projectId': null, 'projectStepId': null}, where: 'projectId = ?', whereArgs: [id]);
+    }
+    await db.delete('project_steps', where: 'projectId = ?', whereArgs: [id]);
+    await db.delete('project_stages', where: 'projectId = ?', whereArgs: [id]);
     return await db.delete('projects', where: 'id = ?', whereArgs: [id]);
   }
-}
 
+  Future<List<ProjectStep>> getProjectSteps(int projectId) async {
+    final db = await instance.database;
+    final result = await db.query('project_steps', where: 'projectId = ?', whereArgs: [projectId], orderBy: 'orderIndex ASC, id ASC');
+    return result.map((e) => ProjectStep.fromMap(e)).toList();
+  }
+
+  Future<List<ProjectStep>> getAllProjectSteps() async {
+    final db = await instance.database;
+    final result = await db.query('project_steps', orderBy: 'projectId ASC, orderIndex ASC, id ASC');
+    return result.map((e) => ProjectStep.fromMap(e)).toList();
+  }
+
+  Future<ProjectStep> createProjectStep(ProjectStep step) async {
+    final db = await instance.database;
+    final id = await db.insert('project_steps', step.toMap());
+    return ProjectStep(
+      id: id,
+      projectId: step.projectId,
+      title: step.title,
+      description: step.description,
+      orderIndex: step.orderIndex,
+      status: step.status,
+      dueDate: step.dueDate,
+      completedAt: step.completedAt,
+      createdAt: step.createdAt,
+      updatedAt: step.updatedAt,
+    );
+  }
+
+  Future<int> updateProjectStep(ProjectStep step) async {
+    final db = await instance.database;
+    return db.update('project_steps', step.toMap(), where: 'id = ?', whereArgs: [step.id]);
+  }
+
+  Future<int> deleteProjectStep(int id) async {
+    final db = await instance.database;
+    return db.delete('project_steps', where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/lib/data/models/project_model.dart
+++ b/lib/data/models/project_model.dart
@@ -5,6 +5,13 @@ class Project {
   final String? startDate;
   final String? endDate;
   final String status; // active, completed, paused, canceled
+  final String? notes;
+  final String? completedAt;
+  final double progress; // 0..100
+  final bool reminderEnabled;
+  final String priority; // baixa, media, alta
+  final String color; // hex string
+  final String icon; // icon key
   final String createdAt;
   final String updatedAt;
 
@@ -15,6 +22,13 @@ class Project {
     this.startDate,
     this.endDate,
     required this.status,
+    this.notes,
+    this.completedAt,
+    this.progress = 0,
+    this.reminderEnabled = false,
+    this.priority = 'media',
+    this.color = '0xFF2196F3',
+    this.icon = 'rocket_launch',
     required this.createdAt,
     required this.updatedAt,
   });
@@ -27,6 +41,13 @@ class Project {
       'startDate': startDate,
       'endDate': endDate,
       'status': status,
+      'notes': notes,
+      'completedAt': completedAt,
+      'progress': progress,
+      'reminderEnabled': reminderEnabled ? 1 : 0,
+      'priority': priority,
+      'color': color,
+      'icon': icon,
       'createdAt': createdAt,
       'updatedAt': updatedAt,
     };
@@ -40,6 +61,13 @@ class Project {
       startDate: map['startDate'],
       endDate: map['endDate'],
       status: map['status'],
+      notes: map['notes'],
+      completedAt: map['completedAt'],
+      progress: (map['progress'] is num) ? (map['progress'] as num).toDouble() : 0,
+      reminderEnabled: map['reminderEnabled'] == 1,
+      priority: map['priority'] ?? 'media',
+      color: map['color'] ?? '0xFF2196F3',
+      icon: map['icon'] ?? 'rocket_launch',
       createdAt: map['createdAt'],
       updatedAt: map['updatedAt'],
     );
@@ -52,6 +80,14 @@ class Project {
     String? startDate,
     String? endDate,
     String? status,
+    String? notes,
+    String? completedAt,
+    bool clearCompletedAt = false,
+    double? progress,
+    bool? reminderEnabled,
+    String? priority,
+    String? color,
+    String? icon,
     String? createdAt,
     String? updatedAt,
   }) {
@@ -62,6 +98,13 @@ class Project {
       startDate: startDate ?? this.startDate,
       endDate: endDate ?? this.endDate,
       status: status ?? this.status,
+      notes: notes ?? this.notes,
+      completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),
+      progress: progress ?? this.progress,
+      reminderEnabled: reminderEnabled ?? this.reminderEnabled,
+      priority: priority ?? this.priority,
+      color: color ?? this.color,
+      icon: icon ?? this.icon,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/lib/data/models/project_model.dart
+++ b/lib/data/models/project_model.dart
@@ -12,6 +12,49 @@ class Project {
   final String priority; // baixa, media, alta
   final String color; // hex string
   final String icon; // icon key
+    this.notes,
+    this.completedAt,
+    this.progress = 0,
+    this.reminderEnabled = false,
+    this.priority = 'media',
+    this.color = '0xFF2196F3',
+    this.icon = 'rocket_launch',
+      'notes': notes,
+      'completedAt': completedAt,
+      'progress': progress,
+      'reminderEnabled': reminderEnabled ? 1 : 0,
+      'priority': priority,
+      'color': color,
+      'icon': icon,
+      notes: map['notes'],
+      completedAt: map['completedAt'],
+      progress: (map['progress'] is num) ? (map['progress'] as num).toDouble() : 0,
+      reminderEnabled: map['reminderEnabled'] == 1,
+      priority: map['priority'] ?? 'media',
+      color: map['color'] ?? '0xFF2196F3',
+      icon: map['icon'] ?? 'rocket_launch',
+    String? notes,
+    String? completedAt,
+    bool clearCompletedAt = false,
+    double? progress,
+    bool? reminderEnabled,
+    String? priority,
+    String? color,
+    String? icon,
+      notes: notes ?? this.notes,
+      completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),
+      progress: progress ?? this.progress,
+      reminderEnabled: reminderEnabled ?? this.reminderEnabled,
+      priority: priority ?? this.priority,
+      color: color ?? this.color,
+      icon: icon ?? this.icon,
+  final String? notes;
+  final String? completedAt;
+  final double progress; // 0..100
+  final bool reminderEnabled;
+  final String priority; // baixa, media, alta
+  final String color; // hex string
+  final String icon; // icon key
   final String createdAt;
   final String updatedAt;
 

--- a/lib/data/models/project_step_model.dart
+++ b/lib/data/models/project_step_model.dart
@@ -1,0 +1,59 @@
+class ProjectStep {
+  final int? id;
+  final int projectId;
+  final String title;
+  final String? description;
+  final int orderIndex;
+  final String status; // pending, in_progress, completed, canceled
+  final String? dueDate;
+  final String? completedAt;
+  final bool reminderEnabled;
+  final String createdAt;
+  final String updatedAt;
+
+  ProjectStep({
+    this.id,
+    required this.projectId,
+    required this.title,
+    this.description,
+    required this.orderIndex,
+    required this.status,
+    this.dueDate,
+    this.completedAt,
+    this.reminderEnabled = false,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'projectId': projectId,
+      'title': title,
+      'description': description,
+      'orderIndex': orderIndex,
+      'status': status,
+      'dueDate': dueDate,
+      'completedAt': completedAt,
+      'reminderEnabled': reminderEnabled ? 1 : 0,
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+    };
+  }
+
+  factory ProjectStep.fromMap(Map<String, dynamic> map) {
+    return ProjectStep(
+      id: map['id'],
+      projectId: map['projectId'],
+      title: map['title'],
+      description: map['description'],
+      orderIndex: map['orderIndex'],
+      status: map['status'],
+      dueDate: map['dueDate'],
+      completedAt: map['completedAt'],
+      reminderEnabled: map['reminderEnabled'] == 1,
+      createdAt: map['createdAt'],
+      updatedAt: map['updatedAt'],
+    );
+  }
+}

--- a/lib/data/models/task_model.dart
+++ b/lib/data/models/task_model.dart
@@ -4,6 +4,7 @@ class Task {
   final String? description;
   final int? categoryId;
   final int? projectId;
+  final int? projectStepId;
   final String priority; // 'baixa', 'media', 'alta'
   final String? date;
   final String? time;
@@ -18,6 +19,7 @@ class Task {
     this.description,
     this.categoryId,
     this.projectId,
+    this.projectStepId,
     required this.priority,
     this.date,
     this.time,
@@ -34,6 +36,7 @@ class Task {
       'description': description,
       'categoryId': categoryId,
       'projectId': projectId,
+      'projectStepId': projectStepId,
       'priority': priority,
       'date': date,
       'time': time,
@@ -51,6 +54,7 @@ class Task {
       description: map['description'],
       categoryId: map['categoryId'],
       projectId: map['projectId'],
+      projectStepId: map['projectStepId'],
       priority: map['priority'],
       date: map['date'],
       time: map['time'],
@@ -67,6 +71,9 @@ class Task {
     String? description,
     int? categoryId,
     int? projectId,
+    int? projectStepId,
+    bool clearProjectId = false,
+    bool clearProjectStepId = false,
     String? priority,
     String? date,
     String? time,
@@ -80,7 +87,8 @@ class Task {
       title: title ?? this.title,
       description: description ?? this.description,
       categoryId: categoryId ?? this.categoryId,
-      projectId: projectId ?? this.projectId,
+      projectId: clearProjectId ? null : (projectId ?? this.projectId),
+      projectStepId: clearProjectStepId ? null : (projectStepId ?? this.projectStepId),
       priority: priority ?? this.priority,
       date: date ?? this.date,
       time: time ?? this.time,

--- a/lib/data/models/task_model.dart
+++ b/lib/data/models/task_model.dart
@@ -5,6 +5,14 @@ class Task {
   final int? categoryId;
   final int? projectId;
   final int? projectStepId;
+    this.projectStepId,
+      'projectStepId': projectStepId,
+      projectStepId: map['projectStepId'],
+    int? projectStepId,
+    bool clearProjectId = false,
+    bool clearProjectStepId = false,
+      projectId: clearProjectId ? null : (projectId ?? this.projectId),
+      projectStepId: clearProjectStepId ? null : (projectStepId ?? this.projectStepId),
   final String priority; // 'baixa', 'media', 'alta'
   final String? date;
   final String? time;

--- a/lib/data/models/transaction_model.dart
+++ b/lib/data/models/transaction_model.dart
@@ -10,6 +10,7 @@ class FinancialTransaction {
   final int? categoryId;
   final String? paymentMethod;
   final String status; // 'pending', 'paid', 'overdue', 'canceled'
+  final bool reminderEnabled;
   final bool isFixed;
   final String recurrenceType; // 'none', 'monthly'
   final String? notes;
@@ -32,6 +33,7 @@ class FinancialTransaction {
     this.categoryId,
     this.paymentMethod,
     required this.status,
+    this.reminderEnabled = false,
     required this.isFixed,
     required this.recurrenceType,
     this.notes,
@@ -55,6 +57,7 @@ class FinancialTransaction {
     int? categoryId,
     String? paymentMethod,
     String? status,
+    bool? reminderEnabled,
     bool? isFixed,
     String? recurrenceType,
     String? notes,
@@ -77,6 +80,7 @@ class FinancialTransaction {
       categoryId: categoryId ?? this.categoryId,
       paymentMethod: paymentMethod ?? this.paymentMethod,
       status: status ?? this.status,
+      reminderEnabled: reminderEnabled ?? this.reminderEnabled,
       isFixed: isFixed ?? this.isFixed,
       recurrenceType: recurrenceType ?? this.recurrenceType,
       notes: notes ?? this.notes,
@@ -102,6 +106,7 @@ class FinancialTransaction {
       'categoryId': categoryId,
       'paymentMethod': paymentMethod,
       'status': status,
+      'reminderEnabled': reminderEnabled ? 1 : 0,
       'isFixed': isFixed ? 1 : 0,
       'recurrenceType': recurrenceType,
       'notes': notes,
@@ -137,6 +142,7 @@ class FinancialTransaction {
       categoryId: map['categoryId'],
       paymentMethod: map['paymentMethod'],
       status: mappedStatus,
+      reminderEnabled: map['reminderEnabled'] == 1,
       isFixed: map['isFixed'] == 1,
       recurrenceType: map['recurrenceType'] ?? 'none',
       notes: map['notes'],

--- a/lib/data/models/transaction_model.dart
+++ b/lib/data/models/transaction_model.dart
@@ -11,6 +11,12 @@ class FinancialTransaction {
   final String? paymentMethod;
   final String status; // 'pending', 'paid', 'overdue', 'canceled'
   final bool reminderEnabled;
+    this.reminderEnabled = false,
+    bool? reminderEnabled,
+      reminderEnabled: reminderEnabled ?? this.reminderEnabled,
+      'reminderEnabled': reminderEnabled ? 1 : 0,
+      reminderEnabled: map['reminderEnabled'] == 1,
+  final bool reminderEnabled;
   final bool isFixed;
   final String recurrenceType; // 'none', 'monthly'
   final String? notes;

--- a/lib/domain/providers.dart
+++ b/lib/domain/providers.dart
@@ -7,10 +7,64 @@ import '../data/models/debt_model.dart';
 import '../data/models/setting_model.dart';
 import '../data/models/transaction_model.dart';
 import '../data/models/project_model.dart';
+import '../data/models/project_step_model.dart';
 import '../data/database/db_helper.dart';
 import '../core/notifications/notification_service.dart';
 
 final dbProvider = Provider<DatabaseHelper>((ref) => DatabaseHelper.instance);
+
+class AppSettingKeys {
+  static const defaultCurrency = 'default_currency';
+  static const homeShowFinancialValues = 'home_show_financial_values';
+  static const financeDiscreteMode = 'finance_discrete_mode';
+  static const financeVisualLock = 'finance_visual_lock';
+  static const privacyHideHomeValues = 'privacy_hide_home_values';
+  static const debtsShowPaid = 'debts_show_paid';
+  static const debtsRemindersDefault = 'debts_reminders_default';
+  static const debtsReminderDaysBefore = 'debts_reminder_days_before';
+  static const projectsShowCompleted = 'projects_show_completed';
+  static const projectsShowPaused = 'projects_show_paused';
+  static const projectsDefaultSort = 'projects_default_sort';
+  static const homeShowProjectsCard = 'home_show_projects_card';
+}
+
+final appSettingsProvider = StateNotifierProvider<AppSettingsNotifier, Map<String, String>>((ref) {
+  return AppSettingsNotifier(ref.watch(dbProvider));
+});
+
+class AppSettingsNotifier extends StateNotifier<Map<String, String>> {
+  final DatabaseHelper db;
+  AppSettingsNotifier(this.db) : super({
+    AppSettingKeys.defaultCurrency: 'BRL',
+    AppSettingKeys.homeShowFinancialValues: 'true',
+    AppSettingKeys.financeDiscreteMode: 'false',
+    AppSettingKeys.financeVisualLock: 'false',
+    AppSettingKeys.privacyHideHomeValues: 'false',
+    AppSettingKeys.debtsShowPaid: 'true',
+    AppSettingKeys.debtsRemindersDefault: 'false',
+    AppSettingKeys.debtsReminderDaysBefore: '0',
+    AppSettingKeys.projectsShowCompleted: 'true',
+    AppSettingKeys.projectsShowPaused: 'true',
+    AppSettingKeys.projectsDefaultSort: 'created_desc',
+    AppSettingKeys.homeShowProjectsCard: 'true',
+  }) {
+    loadSettings();
+  }
+
+  Future<void> loadSettings() async {
+    final loaded = Map<String, String>.from(state);
+    for (final key in state.keys) {
+      final setting = await db.getSetting(key);
+      if (setting != null) loaded[key] = setting.value;
+    }
+    state = loaded;
+  }
+
+  Future<void> setValue(String key, String value) async {
+    await db.saveSetting(AppSetting(key: key, value: value));
+    state = {...state, key: value};
+  }
+}
 
 final themeModeProvider = StateNotifierProvider<ThemeModeNotifier, ThemeMode>((ref) {
   return ThemeModeNotifier(ref.watch(dbProvider));
@@ -66,12 +120,13 @@ class CategoryNotifier extends StateNotifier<List<TaskCategory>> {
 }
 
 final tasksProvider = StateNotifierProvider<TaskNotifier, List<Task>>((ref) {
-  return TaskNotifier(ref.watch(dbProvider));
+  return TaskNotifier(ref.watch(dbProvider), ref);
 });
 
 class TaskNotifier extends StateNotifier<List<Task>> {
   final DatabaseHelper db;
-  TaskNotifier(this.db) : super([]) {
+  final Ref ref;
+  TaskNotifier(this.db, this.ref) : super([]) {
     loadTasks();
   }
 
@@ -106,11 +161,18 @@ class TaskNotifier extends StateNotifier<List<Task>> {
       }
     }
     state = updatedTasks;
+    final projectIds = state.where((t) => t.projectId != null).map((t) => t.projectId!).toSet();
+    for (final id in projectIds) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(id);
+    }
   }
 
   Future<Task> addTaskWithReturn(Task task) async {
     final newTask = await db.createTask(task);
     state = [...state, newTask];
+    if (newTask.projectId != null) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(newTask.projectId!);
+    }
     return newTask;
   }
 
@@ -127,12 +189,21 @@ class TaskNotifier extends StateNotifier<List<Task>> {
       for (final t in state)
         if (t.id == task.id) task else t
     ];
+
+    if (task.projectId != null) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(task.projectId!);
+    }
   }
 
   Future<void> removeTask(int id) async {
+    final taskIdx = state.indexWhere((t) => t.id == id);
+    final projectId = taskIdx == -1 ? null : state[taskIdx].projectId;
     await db.deleteTask(id);
     NotificationService().cancelNotification(id);
     state = state.where((t) => t.id != id).toList();
+    if (projectId != null) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+    }
   }
 
   Future<void> clearCompletedTasks() async {
@@ -165,6 +236,7 @@ class TransactionNotifier extends StateNotifier<List<FinancialTransaction>> {
   Future<void> addTransaction(FinancialTransaction transaction) async {
     final newTransaction = await db.createTransaction(transaction);
     state = [newTransaction, ...state]; // Add to top since it sorted desc usually, though DB sort is date based
+    _syncTransactionReminder(newTransaction);
     _checkDebtStatus(transaction.debtId);
   }
 
@@ -174,6 +246,7 @@ class TransactionNotifier extends StateNotifier<List<FinancialTransaction>> {
       for (final t in state)
         if (t.id == transaction.id) transaction else t
     ];
+    _syncTransactionReminder(transaction);
     _checkDebtStatus(transaction.debtId);
   }
 
@@ -181,7 +254,46 @@ class TransactionNotifier extends StateNotifier<List<FinancialTransaction>> {
     final transaction = state.firstWhere((t) => t.id == id, orElse: () => state.first);
     await db.deleteTransaction(id);
     state = state.where((t) => t.id != id).toList();
+    if (transaction.id != null) {
+      NotificationService().cancelNotification(NotificationService().transactionReminderId(transaction.id!));
+    }
     _checkDebtStatus(transaction.debtId);
+  }
+
+  Future<void> clearCanceledTransactions() async {
+    final canceled = state.where((t) => t.status == 'canceled').toList();
+    for (final t in canceled) {
+      if (t.id == null) continue;
+      await db.deleteTransaction(t.id!);
+      NotificationService().cancelNotification(NotificationService().transactionReminderId(t.id!));
+    }
+    state = state.where((t) => t.status != 'canceled').toList();
+  }
+
+  void _syncTransactionReminder(FinancialTransaction t) {
+    if (t.id == null) return;
+    final reminderId = NotificationService().transactionReminderId(t.id!);
+
+    final shouldCancel = !t.reminderEnabled || t.status == 'paid' || t.status == 'canceled';
+    if (shouldCancel) {
+      NotificationService().cancelNotification(reminderId);
+      return;
+    }
+
+    final targetDate = DateTime.tryParse(t.dueDate ?? t.transactionDate);
+    if (targetDate == null) return;
+    final settings = ref.read(appSettingsProvider);
+    final daysBefore = t.debtId != null ? int.tryParse(settings[AppSettingKeys.debtsReminderDaysBefore] ?? '0') ?? 0 : 0;
+    final reminderBase = targetDate.subtract(Duration(days: daysBefore));
+    final reminderTime = DateTime(reminderBase.year, reminderBase.month, reminderBase.day, 9, 0);
+    if (reminderTime.isBefore(DateTime.now())) return;
+
+    NotificationService().scheduleNotification(
+      id: reminderId,
+      title: t.type == 'income' ? 'Receita prevista próxima' : 'Despesa próxima do vencimento',
+      body: t.title,
+      scheduledDate: reminderTime,
+    );
   }
 
   void _checkDebtStatus(int? debtId) {
@@ -251,12 +363,13 @@ class FinancialCategoryNotifier extends StateNotifier<List<FinancialCategory>> {
 }
 
 final debtsProvider = StateNotifierProvider<DebtNotifier, List<Debt>>((ref) {
-  return DebtNotifier(ref.watch(dbProvider));
+  return DebtNotifier(ref.watch(dbProvider), ref);
 });
 
 class DebtNotifier extends StateNotifier<List<Debt>> {
   final DatabaseHelper db;
-  DebtNotifier(this.db) : super([]) {
+  final Ref ref;
+  DebtNotifier(this.db, this.ref) : super([]) {
     loadDebts();
   }
 
@@ -279,18 +392,32 @@ class DebtNotifier extends StateNotifier<List<Debt>> {
   }
 
   Future<void> removeDebt(int id) async {
+    final installments = ref.read(transactionsProvider).where((t) => t.debtId == id).toList();
+    for (final i in installments) {
+      if (i.id != null) {
+        NotificationService().cancelNotification(NotificationService().transactionReminderId(i.id!));
+      }
+    }
     await db.deleteDebt(id);
     state = state.where((d) => d.id != id).toList();
+  }
+
+  Future<void> clearCanceledDebts() async {
+    final canceledIds = state.where((d) => d.status == 'canceled' && d.id != null).map((d) => d.id!).toList();
+    for (final id in canceledIds) {
+      await removeDebt(id);
+    }
   }
 }
 
 final projectsProvider = StateNotifierProvider<ProjectNotifier, List<Project>>((ref) {
-  return ProjectNotifier(ref.watch(dbProvider));
+  return ProjectNotifier(ref.watch(dbProvider), ref);
 });
 
 class ProjectNotifier extends StateNotifier<List<Project>> {
   final DatabaseHelper db;
-  ProjectNotifier(this.db) : super([]) {
+  final Ref ref;
+  ProjectNotifier(this.db, this.ref) : super([]) {
     loadProjects();
   }
 
@@ -302,19 +429,147 @@ class ProjectNotifier extends StateNotifier<List<Project>> {
   Future<void> addProject(Project project) async {
     final id = await db.createProject(project.toMap());
     state = [project.copyWith(id: id), ...state];
+    _syncProjectReminder(state.first);
   }
 
   Future<void> updateProject(Project project) async {
     await db.updateProject(project.toMap());
+    _syncProjectReminder(project);
     state = [
       for (final p in state)
         if (p.id == project.id) project else p
     ];
   }
 
-  Future<void> removeProject(int id) async {
-    await db.deleteProject(id);
+  Future<void> removeProject(int id, {bool deleteLinkedTasks = false}) async {
+    NotificationService().cancelNotification(NotificationService().projectReminderId(id));
+    await db.deleteProject(id, deleteLinkedTasks: deleteLinkedTasks);
     state = state.where((p) => p.id != id).toList();
+  }
+
+  Future<void> recalculateProgress(int projectId) async {
+    final idx = state.indexWhere((p) => p.id == projectId);
+    if (idx == -1) return;
+    final project = state[idx];
+
+    if (project.status == 'paused') return;
+    if (project.status == 'completed') {
+      final completedProject = project.copyWith(progress: 100, updatedAt: DateTime.now().toIso8601String());
+      await updateProject(completedProject);
+      return;
+    }
+
+    final tasks = ref.read(tasksProvider).where((t) => t.projectId == projectId && t.status != 'canceled').toList();
+    double progress = 0;
+
+    if (tasks.isNotEmpty) {
+      final done = tasks.where((t) => t.status == 'concluida').length;
+      progress = (done / tasks.length) * 100;
+    } else {
+      final steps = ref.read(projectStepsProvider(projectId)).where((s) => s.status != 'canceled').toList();
+      if (steps.isNotEmpty) {
+        final done = steps.where((s) => s.status == 'completed').length;
+        progress = (done / steps.length) * 100;
+      }
+    }
+
+    final updated = project.copyWith(progress: progress, updatedAt: DateTime.now().toIso8601String());
+    await updateProject(updated);
+  }
+
+  void _syncProjectReminder(Project p) {
+    if (p.id == null) return;
+    final reminderId = NotificationService().projectReminderId(p.id!);
+    if (!p.reminderEnabled || p.status == 'completed' || p.status == 'canceled') {
+      NotificationService().cancelNotification(reminderId);
+      return;
+    }
+    final end = p.endDate == null ? null : DateTime.tryParse(p.endDate!);
+    if (end == null) return;
+    final reminderTime = DateTime(end.year, end.month, end.day, 9, 0);
+    if (reminderTime.isBefore(DateTime.now())) return;
+    NotificationService().scheduleNotification(
+      id: reminderId,
+      title: 'Prazo de projeto próximo',
+      body: p.name,
+      scheduledDate: reminderTime,
+    );
   }
 }
 
+final projectStepsProvider = StateNotifierProvider.family<ProjectStepNotifier, List<ProjectStep>, int>((ref, projectId) {
+  return ProjectStepNotifier(ref.watch(dbProvider), projectId, ref);
+});
+
+final allProjectStepsProvider = FutureProvider<List<ProjectStep>>((ref) async {
+  return ref.watch(dbProvider).getAllProjectSteps();
+});
+
+class ProjectStepNotifier extends StateNotifier<List<ProjectStep>> {
+  final DatabaseHelper db;
+  final Ref ref;
+  final int projectId;
+  ProjectStepNotifier(this.db, this.projectId, this.ref) : super([]) {
+    loadSteps();
+  }
+
+  Future<void> loadSteps() async {
+    state = await db.getProjectSteps(projectId);
+  }
+
+  Future<void> addStep(String title, {String? description, String? dueDate, bool reminderEnabled = false}) async {
+    final now = DateTime.now().toIso8601String();
+    final step = ProjectStep(
+      projectId: projectId,
+      title: title,
+      description: description,
+      orderIndex: state.length,
+      status: 'pending',
+      dueDate: dueDate,
+      completedAt: null,
+      reminderEnabled: reminderEnabled,
+      createdAt: now,
+      updatedAt: now,
+    );
+    final newStep = await db.createProjectStep(step);
+    state = [...state, newStep];
+    _syncStepReminder(newStep);
+    await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+  }
+
+  Future<void> updateStep(ProjectStep step) async {
+    await db.updateProjectStep(step);
+    _syncStepReminder(step);
+    state = [
+      for (final s in state)
+        if (s.id == step.id) step else s
+    ];
+    await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+  }
+
+  Future<void> removeStep(int stepId) async {
+    NotificationService().cancelNotification(NotificationService().projectStepReminderId(stepId));
+    await db.deleteProjectStep(stepId);
+    state = state.where((s) => s.id != stepId).toList();
+    await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+  }
+
+  void _syncStepReminder(ProjectStep step) {
+    if (step.id == null) return;
+    final reminderId = NotificationService().projectStepReminderId(step.id!);
+    if (!step.reminderEnabled || step.status == 'completed' || step.status == 'canceled') {
+      NotificationService().cancelNotification(reminderId);
+      return;
+    }
+    final due = step.dueDate == null ? null : DateTime.tryParse(step.dueDate!);
+    if (due == null) return;
+    final reminderTime = DateTime(due.year, due.month, due.day, 9, 0);
+    if (reminderTime.isBefore(DateTime.now())) return;
+    NotificationService().scheduleNotification(
+      id: reminderId,
+      title: 'Prazo de etapa próximo',
+      body: step.title,
+      scheduledDate: reminderTime,
+    );
+  }
+}

--- a/lib/domain/providers.dart
+++ b/lib/domain/providers.dart
@@ -8,6 +8,60 @@ import '../data/models/setting_model.dart';
 import '../data/models/transaction_model.dart';
 import '../data/models/project_model.dart';
 import '../data/models/project_step_model.dart';
+class AppSettingKeys {
+  static const defaultCurrency = 'default_currency';
+  static const homeShowFinancialValues = 'home_show_financial_values';
+  static const financeDiscreteMode = 'finance_discrete_mode';
+  static const financeVisualLock = 'finance_visual_lock';
+  static const privacyHideHomeValues = 'privacy_hide_home_values';
+  static const debtsShowPaid = 'debts_show_paid';
+  static const debtsRemindersDefault = 'debts_reminders_default';
+  static const debtsReminderDaysBefore = 'debts_reminder_days_before';
+  static const projectsShowCompleted = 'projects_show_completed';
+  static const projectsShowPaused = 'projects_show_paused';
+  static const projectsDefaultSort = 'projects_default_sort';
+  static const homeShowProjectsCard = 'home_show_projects_card';
+}
+
+final appSettingsProvider = StateNotifierProvider<AppSettingsNotifier, Map<String, String>>((ref) {
+  return AppSettingsNotifier(ref.watch(dbProvider));
+});
+
+class AppSettingsNotifier extends StateNotifier<Map<String, String>> {
+  final DatabaseHelper db;
+  AppSettingsNotifier(this.db) : super({
+    AppSettingKeys.defaultCurrency: 'BRL',
+    AppSettingKeys.homeShowFinancialValues: 'true',
+    AppSettingKeys.financeDiscreteMode: 'false',
+    AppSettingKeys.financeVisualLock: 'false',
+    AppSettingKeys.privacyHideHomeValues: 'false',
+    AppSettingKeys.debtsShowPaid: 'true',
+    AppSettingKeys.debtsRemindersDefault: 'false',
+    AppSettingKeys.debtsReminderDaysBefore: '0',
+    AppSettingKeys.projectsShowCompleted: 'true',
+    AppSettingKeys.projectsShowPaused: 'true',
+    AppSettingKeys.projectsDefaultSort: 'created_desc',
+    AppSettingKeys.homeShowProjectsCard: 'true',
+  }) {
+    loadSettings();
+  }
+
+  Future<void> loadSettings() async {
+    final loaded = Map<String, String>.from(state);
+    for (final key in state.keys) {
+      final setting = await db.getSetting(key);
+      if (setting != null) loaded[key] = setting.value;
+    }
+    state = loaded;
+  }
+
+  Future<void> setValue(String key, String value) async {
+    await db.saveSetting(AppSetting(key: key, value: value));
+    state = {...state, key: value};
+  }
+}
+
+import '../data/models/project_step_model.dart';
 import '../data/database/db_helper.dart';
 import '../core/notifications/notification_service.dart';
 
@@ -41,8 +95,66 @@ class AppSettingsNotifier extends StateNotifier<Map<String, String>> {
     AppSettingKeys.financeVisualLock: 'false',
     AppSettingKeys.privacyHideHomeValues: 'false',
     AppSettingKeys.debtsShowPaid: 'true',
-    AppSettingKeys.debtsRemindersDefault: 'false',
-    AppSettingKeys.debtsReminderDaysBefore: '0',
+  return TaskNotifier(ref.watch(dbProvider), ref);
+  final Ref ref;
+  TaskNotifier(this.db, this.ref) : super([]) {
+    final projectIds = state.where((t) => t.projectId != null).map((t) => t.projectId!).toSet();
+    for (final id in projectIds) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(id);
+    }
+    if (newTask.projectId != null) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(newTask.projectId!);
+    }
+
+    if (task.projectId != null) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(task.projectId!);
+    }
+    final taskIdx = state.indexWhere((t) => t.id == id);
+    final projectId = taskIdx == -1 ? null : state[taskIdx].projectId;
+    if (projectId != null) {
+      await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+    }
+    _syncTransactionReminder(newTransaction);
+    _syncTransactionReminder(transaction);
+    if (transaction.id != null) {
+      NotificationService().cancelNotification(NotificationService().transactionReminderId(transaction.id!));
+    }
+  Future<void> clearCanceledTransactions() async {
+    final canceled = state.where((t) => t.status == 'canceled').toList();
+    for (final t in canceled) {
+      if (t.id == null) continue;
+      await db.deleteTransaction(t.id!);
+      NotificationService().cancelNotification(NotificationService().transactionReminderId(t.id!));
+    }
+    state = state.where((t) => t.status != 'canceled').toList();
+  }
+
+  void _syncTransactionReminder(FinancialTransaction t) {
+    if (t.id == null) return;
+    final reminderId = NotificationService().transactionReminderId(t.id!);
+
+    final shouldCancel = !t.reminderEnabled || t.status == 'paid' || t.status == 'canceled';
+    if (shouldCancel) {
+      NotificationService().cancelNotification(reminderId);
+      return;
+    }
+
+    final targetDate = DateTime.tryParse(t.dueDate ?? t.transactionDate);
+    if (targetDate == null) return;
+    final settings = ref.read(appSettingsProvider);
+    final daysBefore = t.debtId != null ? int.tryParse(settings[AppSettingKeys.debtsReminderDaysBefore] ?? '0') ?? 0 : 0;
+    final reminderBase = targetDate.subtract(Duration(days: daysBefore));
+    final reminderTime = DateTime(reminderBase.year, reminderBase.month, reminderBase.day, 9, 0);
+    if (reminderTime.isBefore(DateTime.now())) return;
+
+    NotificationService().scheduleNotification(
+      id: reminderId,
+      title: t.type == 'income' ? 'Receita prevista próxima' : 'Despesa próxima do vencimento',
+      body: t.title,
+      scheduledDate: reminderTime,
+    );
+  }
+
     AppSettingKeys.projectsShowCompleted: 'true',
     AppSettingKeys.projectsShowPaused: 'true',
     AppSettingKeys.projectsDefaultSort: 'created_desc',
@@ -226,15 +338,158 @@ class TransactionNotifier extends StateNotifier<List<FinancialTransaction>> {
   final DatabaseHelper db;
   final Ref ref;
   TransactionNotifier(this.db, this.ref) : super([]) {
-    loadTransactions();
+  return DebtNotifier(ref.watch(dbProvider), ref);
+  final Ref ref;
+  DebtNotifier(this.db, this.ref) : super([]) {
+
+    final installments = ref.read(transactionsProvider).where((t) => t.debtId == id).toList();
+    for (final i in installments) {
+      if (i.id != null) {
+        NotificationService().cancelNotification(NotificationService().transactionReminderId(i.id!));
+      }
+    }
+
+  Future<void> clearCanceledDebts() async {
+    final canceledIds = state.where((d) => d.status == 'canceled' && d.id != null).map((d) => d.id!).toList();
+    for (final id in canceledIds) {
+      await removeDebt(id);
+    }
+  }
+  return ProjectNotifier(ref.watch(dbProvider), ref);
+  final Ref ref;
+  ProjectNotifier(this.db, this.ref) : super([]) {
   }
 
-  Future<void> loadTransactions() async {
-    state = await db.getTransactions();
+    _syncProjectReminder(state.first);
+    _syncProjectReminder(project);
+  Future<void> removeProject(int id, {bool deleteLinkedTasks = false}) async {
+    NotificationService().cancelNotification(NotificationService().projectReminderId(id));
+    await db.deleteProject(id, deleteLinkedTasks: deleteLinkedTasks);
+
+  Future<void> recalculateProgress(int projectId) async {
+    final idx = state.indexWhere((p) => p.id == projectId);
+    if (idx == -1) return;
+    final project = state[idx];
+
+    if (project.status == 'paused') return;
+    if (project.status == 'completed') {
+      final completedProject = project.copyWith(progress: 100, updatedAt: DateTime.now().toIso8601String());
+      await updateProject(completedProject);
+      return;
+    }
+
+    final tasks = ref.read(tasksProvider).where((t) => t.projectId == projectId && t.status != 'canceled').toList();
+    double progress = 0;
+
+    if (tasks.isNotEmpty) {
+      final done = tasks.where((t) => t.status == 'concluida').length;
+      progress = (done / tasks.length) * 100;
+    } else {
+      final steps = ref.read(projectStepsProvider(projectId)).where((s) => s.status != 'canceled').toList();
+      if (steps.isNotEmpty) {
+        final done = steps.where((s) => s.status == 'completed').length;
+        progress = (done / steps.length) * 100;
+      }
+    }
+
+    final updated = project.copyWith(progress: progress, updatedAt: DateTime.now().toIso8601String());
+    await updateProject(updated);
   }
 
-  Future<void> addTransaction(FinancialTransaction transaction) async {
-    final newTransaction = await db.createTransaction(transaction);
+  void _syncProjectReminder(Project p) {
+    if (p.id == null) return;
+    final reminderId = NotificationService().projectReminderId(p.id!);
+    if (!p.reminderEnabled || p.status == 'completed' || p.status == 'canceled') {
+      NotificationService().cancelNotification(reminderId);
+      return;
+    }
+    final end = p.endDate == null ? null : DateTime.tryParse(p.endDate!);
+    if (end == null) return;
+    final reminderTime = DateTime(end.year, end.month, end.day, 9, 0);
+    if (reminderTime.isBefore(DateTime.now())) return;
+    NotificationService().scheduleNotification(
+      id: reminderId,
+      title: 'Prazo de projeto próximo',
+      body: p.name,
+      scheduledDate: reminderTime,
+    );
+  }
+final projectStepsProvider = StateNotifierProvider.family<ProjectStepNotifier, List<ProjectStep>, int>((ref, projectId) {
+  return ProjectStepNotifier(ref.watch(dbProvider), projectId, ref);
+});
+
+final allProjectStepsProvider = FutureProvider<List<ProjectStep>>((ref) async {
+  return ref.watch(dbProvider).getAllProjectSteps();
+});
+
+class ProjectStepNotifier extends StateNotifier<List<ProjectStep>> {
+  final DatabaseHelper db;
+  final Ref ref;
+  final int projectId;
+  ProjectStepNotifier(this.db, this.projectId, this.ref) : super([]) {
+    loadSteps();
+  }
+
+  Future<void> loadSteps() async {
+    state = await db.getProjectSteps(projectId);
+  }
+
+  Future<void> addStep(String title, {String? description, String? dueDate, bool reminderEnabled = false}) async {
+    final now = DateTime.now().toIso8601String();
+    final step = ProjectStep(
+      projectId: projectId,
+      title: title,
+      description: description,
+      orderIndex: state.length,
+      status: 'pending',
+      dueDate: dueDate,
+      completedAt: null,
+      reminderEnabled: reminderEnabled,
+      createdAt: now,
+      updatedAt: now,
+    );
+    final newStep = await db.createProjectStep(step);
+    state = [...state, newStep];
+    _syncStepReminder(newStep);
+    await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+  }
+
+  Future<void> updateStep(ProjectStep step) async {
+    await db.updateProjectStep(step);
+    _syncStepReminder(step);
+    state = [
+      for (final s in state)
+        if (s.id == step.id) step else s
+    ];
+    await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+  }
+
+  Future<void> removeStep(int stepId) async {
+    NotificationService().cancelNotification(NotificationService().projectStepReminderId(stepId));
+    await db.deleteProjectStep(stepId);
+    state = state.where((s) => s.id != stepId).toList();
+    await ref.read(projectsProvider.notifier).recalculateProgress(projectId);
+  }
+
+  void _syncStepReminder(ProjectStep step) {
+    if (step.id == null) return;
+    final reminderId = NotificationService().projectStepReminderId(step.id!);
+    if (!step.reminderEnabled || step.status == 'completed' || step.status == 'canceled') {
+      NotificationService().cancelNotification(reminderId);
+      return;
+    }
+    final due = step.dueDate == null ? null : DateTime.tryParse(step.dueDate!);
+    if (due == null) return;
+    final reminderTime = DateTime(due.year, due.month, due.day, 9, 0);
+    if (reminderTime.isBefore(DateTime.now())) return;
+    NotificationService().scheduleNotification(
+      id: reminderId,
+      title: 'Prazo de etapa próximo',
+      body: step.title,
+      scheduledDate: reminderTime,
+    );
+  }
+}
     state = [newTransaction, ...state]; // Add to top since it sorted desc usually, though DB sort is date based
     _syncTransactionReminder(newTransaction);
     _checkDebtStatus(transaction.debtId);

--- a/lib/features/calendar/calendar_screen.dart
+++ b/lib/features/calendar/calendar_screen.dart
@@ -7,18 +7,9 @@ import '../../data/models/transaction_model.dart';
 import '../../data/models/project_model.dart';
 import '../../data/models/project_step_model.dart';
 import '../../data/models/debt_model.dart';
-import '../tasks/create_task_screen.dart';
 import '../finance/create_transaction_screen.dart';
 import '../debts/debt_details_screen.dart';
 import '../projects/project_details_screen.dart';
-
-class CalendarScreen extends ConsumerStatefulWidget {
-  const CalendarScreen({super.key});
-
-  @override
-  ConsumerState<CalendarScreen> createState() => _CalendarScreenState();
-}
-
 enum CalendarEventType { task, expense, income, debtInstallment, projectDeadline, projectStepDeadline }
 
 class CalendarEventItem {
@@ -32,6 +23,217 @@ class CalendarEventItem {
     required this.type,
     required this.title,
     required this.date,
+    required this.data,
+    this.projectId,
+  });
+}
+
+    final transactions = ref.watch(transactionsProvider);
+    final projects = ref.watch(projectsProvider);
+    final debts = ref.watch(debtsProvider);
+    final allStepsAsync = ref.watch(allProjectStepsProvider);
+
+    final allSteps = allStepsAsync.value ?? <ProjectStep>[];
+    final events = _buildEvents(tasks, transactions, projects, allSteps);
+
+    final selectedEvents = events.where((e) => _isSameDate(e.date, _selectedDay)).toList();
+
+    final taskItems = selectedEvents.where((e) => e.type == CalendarEventType.task).toList();
+    final financeItems = selectedEvents.where((e) => e.type == CalendarEventType.expense || e.type == CalendarEventType.income).toList();
+    final debtItems = selectedEvents.where((e) => e.type == CalendarEventType.debtInstallment).toList();
+    final projectItems = selectedEvents.where((e) => e.type == CalendarEventType.projectDeadline || e.type == CalendarEventType.projectStepDeadline).toList();
+        onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const CreateTaskScreen())),
+            firstDay: DateTime.utc(2020, 1, 1),
+            lastDay: DateTime.utc(2035, 12, 31),
+            eventLoader: (day) => events.where((e) => isSameDay(e.date, day)).toList(),
+            calendarBuilders: CalendarBuilders(
+              markerBuilder: (context, day, dayEvents) {
+                if (dayEvents.isEmpty) return const SizedBox.shrink();
+                final items = dayEvents.cast<CalendarEventItem>();
+                final colors = items.map((e) => _colorForType(e.type, projects, e.projectId)).toSet().toList();
+                return Positioned(
+                  bottom: 1,
+                  child: Row(
+                    children: colors.take(4).map((c) => Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 1),
+                      width: 6,
+                      height: 6,
+                      decoration: BoxDecoration(color: c, shape: BoxShape.circle),
+                    )).toList(),
+                  ),
+                );
+              },
+            ),
+            child: selectedEvents.isEmpty
+                ? const Center(child: Text('Nenhum evento para esta data.'))
+                : ListView(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    children: [
+                      _buildSection('Tarefas', taskItems, projects, debts),
+                      _buildSection('Finanças', financeItems, projects, debts),
+                      _buildSection('Dívidas', debtItems, projects, debts),
+                      _buildSection('Projetos', projectItems, projects, debts),
+                    ],
+          ),
+
+  List<CalendarEventItem> _buildEvents(
+    List<Task> tasks,
+    List<FinancialTransaction> transactions,
+    List<Project> projects,
+    List<ProjectStep> steps,
+  ) {
+    final events = <CalendarEventItem>[];
+
+    for (final t in tasks) {
+      if (t.date == null) continue;
+      final dt = DateTime.tryParse(t.date!);
+      if (dt == null) continue;
+      events.add(CalendarEventItem(type: CalendarEventType.task, title: t.title, date: dt, data: t));
+    }
+
+    for (final tr in transactions) {
+      if (tr.status == 'canceled') continue;
+      if (tr.type == 'expense') {
+        final due = tr.dueDate == null ? null : DateTime.tryParse(tr.dueDate!);
+        if (due != null) {
+          events.add(CalendarEventItem(
+            type: tr.debtId != null ? CalendarEventType.debtInstallment : CalendarEventType.expense,
+            title: tr.title,
+            date: due,
+            data: tr,
+          ));
+        }
+      }
+      if (tr.type == 'income' && (tr.status == 'pending' || tr.status == 'overdue')) {
+        final dt = DateTime.tryParse(tr.dueDate ?? tr.transactionDate);
+        if (dt != null) {
+          events.add(CalendarEventItem(type: CalendarEventType.income, title: tr.title, date: dt, data: tr));
+        }
+      }
+    }
+
+    for (final p in projects) {
+      if (p.endDate == null) continue;
+      final dt = DateTime.tryParse(p.endDate!);
+      if (dt == null) continue;
+      events.add(CalendarEventItem(type: CalendarEventType.projectDeadline, title: p.name, date: dt, data: p, projectId: p.id));
+    }
+
+    for (final s in steps) {
+      if (s.dueDate == null || s.status == 'canceled') continue;
+      final dt = DateTime.tryParse(s.dueDate!);
+      if (dt == null) continue;
+      events.add(CalendarEventItem(
+        type: CalendarEventType.projectStepDeadline,
+        title: s.title,
+        date: dt,
+        data: s,
+        projectId: s.projectId,
+      ));
+    }
+
+    return events;
+  }
+
+  Widget _buildSection(String title, List<CalendarEventItem> items, List<Project> projects, List<Debt> debts) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 6),
+            ...items.map((e) => ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.circle, size: 12, color: _colorForType(e.type, projects, e.projectId)),
+                  title: Text(e.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+                  subtitle: Text(_labelForType(e.type)),
+                  onTap: () => _openEventDetails(e, debts, projects),
+                )),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openEventDetails(CalendarEventItem e, List<Debt> debts, List<Project> projects) {
+    if (e.type == CalendarEventType.task) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTaskScreen(task: e.data as Task)));
+      return;
+    }
+
+    if (e.type == CalendarEventType.expense || e.type == CalendarEventType.income) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTransactionScreen(transaction: e.data as FinancialTransaction)));
+      return;
+    }
+
+    if (e.type == CalendarEventType.debtInstallment) {
+      final tr = e.data as FinancialTransaction;
+      final idx = debts.indexWhere((d) => d.id == tr.debtId);
+      if (idx != -1) {
+        Navigator.push(context, MaterialPageRoute(builder: (_) => DebtDetailsScreen(debt: debts[idx])));
+      }
+      return;
+    }
+
+    if (e.type == CalendarEventType.projectDeadline) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => ProjectDetailsScreen(project: e.data as Project)));
+      return;
+    }
+
+    if (e.type == CalendarEventType.projectStepDeadline) {
+      final idx = projects.indexWhere((p) => p.id == e.projectId);
+      if (idx != -1) {
+        Navigator.push(context, MaterialPageRoute(builder: (_) => ProjectDetailsScreen(project: projects[idx])));
+      }
+    }
+  }
+
+  Color _colorForType(CalendarEventType type, List<Project> projects, int? projectId) {
+    switch (type) {
+      case CalendarEventType.task:
+        return Colors.blue;
+      case CalendarEventType.expense:
+        return Colors.red;
+      case CalendarEventType.income:
+        return Colors.green;
+      case CalendarEventType.debtInstallment:
+        return Colors.orange;
+      case CalendarEventType.projectDeadline:
+        return Colors.purple;
+      case CalendarEventType.projectStepDeadline:
+        if (projectId == null) return Colors.indigo;
+        final idx = projects.indexWhere((p) => p.id == projectId);
+        if (idx == -1) return Colors.indigo;
+        return Color(int.parse(projects[idx].color));
+    }
+  }
+
+  String _labelForType(CalendarEventType type) {
+    switch (type) {
+      case CalendarEventType.task:
+        return 'Tarefa';
+      case CalendarEventType.expense:
+        return 'Despesa';
+      case CalendarEventType.income:
+        return 'Receita prevista';
+      case CalendarEventType.debtInstallment:
+        return 'Parcela de dívida';
+      case CalendarEventType.projectDeadline:
+        return 'Prazo do projeto';
+      case CalendarEventType.projectStepDeadline:
+        return 'Prazo da etapa';
+    }
+  }
+
+  bool _isSameDate(DateTime date, DateTime? selected) {
+    if (selected == null) return false;
+    return date.year == selected.year && date.month == selected.month && date.day == selected.day;
+  }
     required this.data,
     this.projectId,
   });

--- a/lib/features/calendar/calendar_screen.dart
+++ b/lib/features/calendar/calendar_screen.dart
@@ -2,13 +2,39 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:table_calendar/table_calendar.dart';
 import '../../domain/providers.dart';
+import '../../data/models/task_model.dart';
+import '../../data/models/transaction_model.dart';
+import '../../data/models/project_model.dart';
+import '../../data/models/project_step_model.dart';
+import '../../data/models/debt_model.dart';
 import '../tasks/create_task_screen.dart';
+import '../finance/create_transaction_screen.dart';
+import '../debts/debt_details_screen.dart';
+import '../projects/project_details_screen.dart';
 
 class CalendarScreen extends ConsumerStatefulWidget {
   const CalendarScreen({super.key});
 
   @override
   ConsumerState<CalendarScreen> createState() => _CalendarScreenState();
+}
+
+enum CalendarEventType { task, expense, income, debtInstallment, projectDeadline, projectStepDeadline }
+
+class CalendarEventItem {
+  final CalendarEventType type;
+  final String title;
+  final DateTime date;
+  final dynamic data;
+  final int? projectId;
+
+  CalendarEventItem({
+    required this.type,
+    required this.title,
+    required this.date,
+    required this.data,
+    this.projectId,
+  });
 }
 
 class _CalendarScreenState extends ConsumerState<CalendarScreen> {
@@ -24,26 +50,32 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   @override
   Widget build(BuildContext context) {
     final tasks = ref.watch(tasksProvider);
-    
-    final tasksForDay = tasks.where((t) {
-      if (_selectedDay == null) return false;
-      return t.date == _selectedDay!.toIso8601String().substring(0, 10);
-    }).toList();
+    final transactions = ref.watch(transactionsProvider);
+    final projects = ref.watch(projectsProvider);
+    final debts = ref.watch(debtsProvider);
+    final allStepsAsync = ref.watch(allProjectStepsProvider);
+
+    final allSteps = allStepsAsync.value ?? <ProjectStep>[];
+    final events = _buildEvents(tasks, transactions, projects, allSteps);
+
+    final selectedEvents = events.where((e) => _isSameDate(e.date, _selectedDay)).toList();
+
+    final taskItems = selectedEvents.where((e) => e.type == CalendarEventType.task).toList();
+    final financeItems = selectedEvents.where((e) => e.type == CalendarEventType.expense || e.type == CalendarEventType.income).toList();
+    final debtItems = selectedEvents.where((e) => e.type == CalendarEventType.debtInstallment).toList();
+    final projectItems = selectedEvents.where((e) => e.type == CalendarEventType.projectDeadline || e.type == CalendarEventType.projectStepDeadline).toList();
 
     return Scaffold(
       appBar: AppBar(title: const Text('Calendário')),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          // Navigating to Create Task Screen could pass initial date, handled normally now.
-          Navigator.push(context, MaterialPageRoute(builder: (_) => const CreateTaskScreen()));
-        },
+        onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const CreateTaskScreen())),
         child: const Icon(Icons.add),
       ),
       body: Column(
         children: [
           TableCalendar(
-            firstDay: DateTime.utc(2020, 10, 16),
-            lastDay: DateTime.utc(2030, 3, 14),
+            firstDay: DateTime.utc(2020, 1, 1),
+            lastDay: DateTime.utc(2035, 12, 31),
             focusedDay: _focusedDay,
             selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
             onDaySelected: (selectedDay, focusedDay) {
@@ -52,35 +84,205 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                 _focusedDay = focusedDay;
               });
             },
+            eventLoader: (day) => events.where((e) => isSameDay(e.date, day)).toList(),
             calendarStyle: const CalendarStyle(
               todayDecoration: BoxDecoration(color: Colors.blueAccent, shape: BoxShape.circle),
               selectedDecoration: BoxDecoration(color: Colors.blue, shape: BoxShape.circle),
             ),
+            calendarBuilders: CalendarBuilders(
+              markerBuilder: (context, day, dayEvents) {
+                if (dayEvents.isEmpty) return const SizedBox.shrink();
+                final items = dayEvents.cast<CalendarEventItem>();
+                final colors = items.map((e) => _colorForType(e.type, projects, e.projectId)).toSet().toList();
+                return Positioned(
+                  bottom: 1,
+                  child: Row(
+                    children: colors.take(4).map((c) => Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 1),
+                      width: 6,
+                      height: 6,
+                      decoration: BoxDecoration(color: c, shape: BoxShape.circle),
+                    )).toList(),
+                  ),
+                );
+              },
+            ),
           ),
           const Divider(),
           Expanded(
-            child: tasksForDay.isEmpty
-                ? const Center(child: Text('Nenhuma tarefa para esta data.'))
-                : ListView.builder(
-                    itemCount: tasksForDay.length,
-                    itemBuilder: (ctx, i) {
-                      final t = tasksForDay[i];
-                      return ListTile(
-                        leading: Icon(
-                          t.status == 'concluida' ? Icons.check_circle : Icons.circle_outlined,
-                          color: t.status == 'concluida' ? Colors.green : Colors.grey,
-                        ),
-                        title: Text(t.title, style: TextStyle(decoration: t.status == 'concluida' ? TextDecoration.lineThrough : null)),
-                        subtitle: Text('${t.time ?? ""} - Priority: ${t.priority.toUpperCase()}'),
-                        onTap: () {
-                           Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTaskScreen(task: t)));
-                        },
-                      );
-                    },
+            child: selectedEvents.isEmpty
+                ? const Center(child: Text('Nenhum evento para esta data.'))
+                : ListView(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    children: [
+                      _buildSection('Tarefas', taskItems, projects, debts),
+                      _buildSection('Finanças', financeItems, projects, debts),
+                      _buildSection('Dívidas', debtItems, projects, debts),
+                      _buildSection('Projetos', projectItems, projects, debts),
+                    ],
                   ),
-          )
+          ),
         ],
       ),
     );
+  }
+
+  List<CalendarEventItem> _buildEvents(
+    List<Task> tasks,
+    List<FinancialTransaction> transactions,
+    List<Project> projects,
+    List<ProjectStep> steps,
+  ) {
+    final events = <CalendarEventItem>[];
+
+    for (final t in tasks) {
+      if (t.date == null) continue;
+      final dt = DateTime.tryParse(t.date!);
+      if (dt == null) continue;
+      events.add(CalendarEventItem(type: CalendarEventType.task, title: t.title, date: dt, data: t));
+    }
+
+    for (final tr in transactions) {
+      if (tr.status == 'canceled') continue;
+      if (tr.type == 'expense') {
+        final due = tr.dueDate == null ? null : DateTime.tryParse(tr.dueDate!);
+        if (due != null) {
+          events.add(CalendarEventItem(
+            type: tr.debtId != null ? CalendarEventType.debtInstallment : CalendarEventType.expense,
+            title: tr.title,
+            date: due,
+            data: tr,
+          ));
+        }
+      }
+      if (tr.type == 'income' && (tr.status == 'pending' || tr.status == 'overdue')) {
+        final dt = DateTime.tryParse(tr.dueDate ?? tr.transactionDate);
+        if (dt != null) {
+          events.add(CalendarEventItem(type: CalendarEventType.income, title: tr.title, date: dt, data: tr));
+        }
+      }
+    }
+
+    for (final p in projects) {
+      if (p.endDate == null) continue;
+      final dt = DateTime.tryParse(p.endDate!);
+      if (dt == null) continue;
+      events.add(CalendarEventItem(type: CalendarEventType.projectDeadline, title: p.name, date: dt, data: p, projectId: p.id));
+    }
+
+    for (final s in steps) {
+      if (s.dueDate == null || s.status == 'canceled') continue;
+      final dt = DateTime.tryParse(s.dueDate!);
+      if (dt == null) continue;
+      events.add(CalendarEventItem(
+        type: CalendarEventType.projectStepDeadline,
+        title: s.title,
+        date: dt,
+        data: s,
+        projectId: s.projectId,
+      ));
+    }
+
+    return events;
+  }
+
+  Widget _buildSection(String title, List<CalendarEventItem> items, List<Project> projects, List<Debt> debts) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 6),
+            ...items.map((e) => ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.circle, size: 12, color: _colorForType(e.type, projects, e.projectId)),
+                  title: Text(e.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+                  subtitle: Text(_labelForType(e.type)),
+                  onTap: () => _openEventDetails(e, debts, projects),
+                )),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openEventDetails(CalendarEventItem e, List<Debt> debts, List<Project> projects) {
+    if (e.type == CalendarEventType.task) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTaskScreen(task: e.data as Task)));
+      return;
+    }
+
+    if (e.type == CalendarEventType.expense || e.type == CalendarEventType.income) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTransactionScreen(transaction: e.data as FinancialTransaction)));
+      return;
+    }
+
+    if (e.type == CalendarEventType.debtInstallment) {
+      final tr = e.data as FinancialTransaction;
+      final idx = debts.indexWhere((d) => d.id == tr.debtId);
+      if (idx != -1) {
+        Navigator.push(context, MaterialPageRoute(builder: (_) => DebtDetailsScreen(debt: debts[idx])));
+      }
+      return;
+    }
+
+    if (e.type == CalendarEventType.projectDeadline) {
+      Navigator.push(context, MaterialPageRoute(builder: (_) => ProjectDetailsScreen(project: e.data as Project)));
+      return;
+    }
+
+    if (e.type == CalendarEventType.projectStepDeadline) {
+      final idx = projects.indexWhere((p) => p.id == e.projectId);
+      if (idx != -1) {
+        Navigator.push(context, MaterialPageRoute(builder: (_) => ProjectDetailsScreen(project: projects[idx])));
+      }
+    }
+  }
+
+  Color _colorForType(CalendarEventType type, List<Project> projects, int? projectId) {
+    switch (type) {
+      case CalendarEventType.task:
+        return Colors.blue;
+      case CalendarEventType.expense:
+        return Colors.red;
+      case CalendarEventType.income:
+        return Colors.green;
+      case CalendarEventType.debtInstallment:
+        return Colors.orange;
+      case CalendarEventType.projectDeadline:
+        return Colors.purple;
+      case CalendarEventType.projectStepDeadline:
+        if (projectId == null) return Colors.indigo;
+        final idx = projects.indexWhere((p) => p.id == projectId);
+        if (idx == -1) return Colors.indigo;
+        return Color(int.parse(projects[idx].color));
+    }
+  }
+
+  String _labelForType(CalendarEventType type) {
+    switch (type) {
+      case CalendarEventType.task:
+        return 'Tarefa';
+      case CalendarEventType.expense:
+        return 'Despesa';
+      case CalendarEventType.income:
+        return 'Receita prevista';
+      case CalendarEventType.debtInstallment:
+        return 'Parcela de dívida';
+      case CalendarEventType.projectDeadline:
+        return 'Prazo do projeto';
+      case CalendarEventType.projectStepDeadline:
+        return 'Prazo da etapa';
+    }
+  }
+
+  bool _isSameDate(DateTime date, DateTime? selected) {
+    if (selected == null) return false;
+    return date.year == selected.year && date.month == selected.month && date.day == selected.day;
   }
 }

--- a/lib/features/dashboard/app_drawer.dart
+++ b/lib/features/dashboard/app_drawer.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import '../finance/finance_screen.dart';
 import '../debts/debts_screen.dart';
 import '../projects/projects_screen.dart';
+import '../calendar/calendar_screen.dart';
+import '../statistics/stats_screen.dart';
+import '../settings/settings_screen.dart';
+import '../settings/categories_screen.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({super.key});
@@ -49,6 +53,38 @@ class AppDrawer extends StatelessWidget {
             onTap: () {
               Navigator.pop(context);
               Navigator.push(context, MaterialPageRoute(builder: (_) => const ProjectsScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.calendar_month),
+            title: const Text('Calendário'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const CalendarScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.category),
+            title: const Text('Categorias'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const CategoriesScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.pie_chart),
+            title: const Text('Estatísticas'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const StatsScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.settings),
+            title: const Text('Configurações'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const SettingsScreen()));
             },
           ),
         ],

--- a/lib/features/dashboard/app_drawer.dart
+++ b/lib/features/dashboard/app_drawer.dart
@@ -6,6 +6,42 @@ import '../calendar/calendar_screen.dart';
 import '../statistics/stats_screen.dart';
 import '../settings/settings_screen.dart';
 import '../settings/categories_screen.dart';
+          ListTile(
+            leading: const Icon(Icons.calendar_month),
+            title: const Text('Calendário'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const CalendarScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.category),
+            title: const Text('Categorias'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const CategoriesScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.pie_chart),
+            title: const Text('Estatísticas'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const StatsScreen()));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.settings),
+            title: const Text('Configurações'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const SettingsScreen()));
+            },
+          ),
+import '../calendar/calendar_screen.dart';
+import '../statistics/stats_screen.dart';
+import '../settings/settings_screen.dart';
+import '../settings/categories_screen.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({super.key});

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -5,7 +5,11 @@ import '../tasks/create_task_screen.dart';
 import '../tasks/task_list_screen.dart';
 import '../calendar/calendar_screen.dart';
 import '../settings/settings_screen.dart';
+import '../settings/categories_screen.dart';
 import '../statistics/stats_screen.dart';
+import '../finance/finance_screen.dart';
+import '../debts/debts_screen.dart';
+import '../projects/projects_screen.dart';
 import 'app_drawer.dart';
 import 'package:intl/intl.dart';
 
@@ -18,28 +22,31 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   int _currentIndex = 0;
-  
-  final List<Widget> _pages = [
+
+  late final List<Widget> _pages = [
     const TaskDashboard(),
     const TaskListScreen(),
-    const CalendarScreen(),
-    const StatsScreen(),
-    const SettingsScreen(),
+    const FinanceScreen(),
+    const ProjectsScreen(),
+    const MoreScreen(),
   ];
 
   @override
   Widget build(BuildContext context) {
+    final showFab = _currentIndex == 0 || _currentIndex == 1;
     return Scaffold(
       body: _pages[_currentIndex],
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => const CreateTaskScreen()),
-          );
-        },
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: showFab
+          ? FloatingActionButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const CreateTaskScreen()),
+                );
+              },
+              child: const Icon(Icons.add),
+            )
+          : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,
@@ -48,145 +55,308 @@ class _HomeScreenState extends State<HomeScreen> {
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Início'),
           BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Tarefas'),
-          BottomNavigationBarItem(icon: Icon(Icons.calendar_month), label: 'Calendário'),
-          BottomNavigationBarItem(icon: Icon(Icons.pie_chart), label: 'Estatísticas'),
-          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Ajustes'),
+          BottomNavigationBarItem(icon: Icon(Icons.account_balance_wallet), label: 'Finanças'),
+          BottomNavigationBarItem(icon: Icon(Icons.rocket_launch), label: 'Projetos'),
+          BottomNavigationBarItem(icon: Icon(Icons.menu), label: 'Mais'),
         ],
       ),
     );
   }
 }
 
-class TaskDashboard extends ConsumerWidget {
-  const TaskDashboard({super.key});
+class MoreScreen extends StatelessWidget {
+  const MoreScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final tasks = ref.watch(tasksProvider);
-    final transactions = ref.watch(transactionsProvider);
-    
-    final pd = tasks.where((t) => t.status == 'pendente').length;
-    final cd = tasks.where((t) => t.status == 'concluida').length;
-    final ad = tasks.where((t) => t.status == 'atrasada').length;
-    
-    final todayStr = DateFormat('yyyy-MM-dd').format(DateTime.now());
-    final todayTasks = tasks.where((t) => t.date == todayStr).toList();
-    
-    double saldo = 0;
-    for (var t in transactions) {
-      if (t.status == 'canceled') continue;
-      
-      if (t.status == 'paid') {
-        if (t.type == 'income') saldo += t.amount;
-        else if (t.type == 'expense') saldo -= t.amount;
-      }
-    }
-
+  Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('DiasOrganize', style: TextStyle(fontWeight: FontWeight.bold)),
-        centerTitle: false,
-      ),
-      drawer: const AppDrawer(),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Resumo Financeiro
-            Card(
-              color: Colors.blue.shade50,
-              elevation: 0,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12), side: BorderSide(color: Colors.blue.shade200)),
-              child: ListTile(
-                leading: const Icon(Icons.account_balance_wallet, color: Colors.blue, size: 36),
-                title: const Text('Saldo Atual', style: TextStyle(fontSize: 14)),
-                subtitle: Text('\$${saldo.toStringAsFixed(2)}', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: saldo >= 0 ? Colors.green.shade700 : Colors.red.shade700)),
-              ),
-            ),
-            const SizedBox(height: 24),
-            const Text(
-              'Resumo do dia',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                _StatCard(title: 'Pendentes', count: pd, color: Colors.blue),
-                _StatCard(title: 'Concluídas', count: cd, color: Colors.green),
-                _StatCard(title: 'Atrasadas', count: ad, color: Colors.red),
-              ],
-            ),
-            const SizedBox(height: 30),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text('Tarefas de hoje', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                if (todayTasks.isNotEmpty)
-                  Text('${todayTasks.length} tarefa(s)'),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Expanded(
-              child: todayTasks.isEmpty
-                  ? const Center(child: Text('Nenhuma tarefa para hoje! 🎉'))
-                  : ListView.builder(
-                      itemCount: todayTasks.length,
-                      itemBuilder: (ctx, i) {
-                        final t = todayTasks[i];
-                        return Card(
-                          margin: const EdgeInsets.only(bottom: 8),
-                          child: ListTile(
-                            title: Text(t.title, style: TextStyle(decoration: t.status == 'concluida' ? TextDecoration.lineThrough : null)),
-                            subtitle: Text('${t.priority.toUpperCase()} - ${t.status}'),
-                            trailing: Icon(
-                              t.status == 'concluida' ? Icons.check_circle : Icons.circle_outlined,
-                              color: t.status == 'concluida' ? Colors.green : Colors.grey,
-                            ),
-                            onTap: () {
-                              ref.read(tasksProvider.notifier).updateTask(
-                                t.copyWith(
-                                  status: t.status == 'concluida' ? 'pendente' : 'concluida',
-                                  updatedAt: DateTime.now().toIso8601String()
-                                )
-                              );
-                            },
-                          ),
-                        );
-                      },
-                    ),
-            ),
-          ],
-        ),
+      appBar: AppBar(title: const Text('Mais módulos')),
+      body: ListView(
+        children: [
+          const ListTile(
+            title: Text('Acesso rápido', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.grey)),
+          ),
+          ListTile(
+            leading: const Icon(Icons.money_off),
+            title: const Text('Dívidas'),
+            subtitle: const Text('Acesse rapidamente suas dívidas e parcelas'),
+            onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const DebtsScreen())),
+          ),
+          const Divider(),
+          const ListTile(
+            title: Text('Outros recursos', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.grey)),
+          ),
+          ListTile(
+            leading: const Icon(Icons.calendar_month),
+            title: const Text('Calendário'),
+            onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const CalendarScreen())),
+          ),
+          ListTile(
+            leading: const Icon(Icons.category),
+            title: const Text('Categorias'),
+            onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const CategoriesScreen())),
+          ),
+          ListTile(
+            leading: const Icon(Icons.pie_chart),
+            title: const Text('Estatísticas'),
+            onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const StatsScreen())),
+          ),
+          ListTile(
+            leading: const Icon(Icons.settings),
+            title: const Text('Configurações'),
+            onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const SettingsScreen())),
+          ),
+        ],
       ),
     );
   }
 }
 
-class _StatCard extends StatelessWidget {
+class TaskDashboard extends ConsumerStatefulWidget {
+  const TaskDashboard({super.key});
+
+  @override
+  ConsumerState<TaskDashboard> createState() => _TaskDashboardState();
+}
+
+class _TaskDashboardState extends ConsumerState<TaskDashboard> {
+  bool _temporaryUnlock = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ref = this.ref;
+    final tasks = ref.watch(tasksProvider);
+    final transactions = ref.watch(transactionsProvider);
+    final projects = ref.watch(projectsProvider);
+    final debts = ref.watch(debtsProvider);
+    final appSettings = ref.watch(appSettingsProvider);
+
+    final currency = appSettings[AppSettingKeys.defaultCurrency] ?? 'BRL';
+    final showFinancial = (appSettings[AppSettingKeys.homeShowFinancialValues] ?? 'true') == 'true';
+    final privacyHide = (appSettings[AppSettingKeys.privacyHideHomeValues] ?? 'false') == 'true';
+    final discreteMode = (appSettings[AppSettingKeys.financeDiscreteMode] ?? 'false') == 'true';
+    final visualLock = (appSettings[AppSettingKeys.financeVisualLock] ?? 'false') == 'true';
+    final showProjectsCard = (appSettings[AppSettingKeys.homeShowProjectsCard] ?? 'true') == 'true';
+    final shouldMask = !showFinancial || privacyHide || discreteMode || (visualLock && !_temporaryUnlock);
+
+    final now = DateTime.now();
+    final todayStr = DateFormat('yyyy-MM-dd').format(now);
+
+    final todayTasks = tasks.where((t) => t.date == todayStr).toList();
+
+    final monthTransactions = transactions.where((t) {
+      final dt = DateTime.tryParse(t.transactionDate);
+      return dt != null && dt.year == now.year && dt.month == now.month && t.status != 'canceled';
+    }).toList();
+
+    final receitasMes = monthTransactions.where((t) => t.type == 'income').fold<double>(0, (sum, t) => sum + t.amount);
+    final despesasMes = monthTransactions.where((t) => t.type == 'expense').fold<double>(0, (sum, t) => sum + t.amount);
+    final saldoPrevisto = receitasMes - despesasMes;
+
+    final receitasRealizadas = monthTransactions.where((t) => t.type == 'income' && t.status == 'paid').fold<double>(0, (sum, t) => sum + t.amount);
+    final despesasRealizadas = monthTransactions.where((t) => t.type == 'expense' && t.status == 'paid').fold<double>(0, (sum, t) => sum + t.amount);
+    final saldoRealizado = receitasRealizadas - despesasRealizadas;
+
+    final debtTransactions = transactions.where((t) => t.debtId != null && t.status != 'canceled').toList();
+    final totalDividas = debts.where((d) => d.status != 'paid' && d.status != 'canceled').fold<double>(0, (sum, d) => sum + d.totalAmount);
+    final pagoDividas = debtTransactions.where((t) => t.status == 'paid' && t.type == 'expense').fold<double>(0, (sum, t) => sum + t.amount);
+    final valorRestante = (totalDividas - pagoDividas).clamp(0, double.infinity);
+
+    final proximasParcelas = debtTransactions.where((t) {
+      final due = t.dueDate == null ? null : DateTime.tryParse(t.dueDate!);
+      return due != null && due.isAfter(now) && t.status != 'paid';
+    }).toList()
+      ..sort((a, b) => DateTime.parse(a.dueDate!).compareTo(DateTime.parse(b.dueDate!)));
+
+    final proximaParcela = proximasParcelas.isEmpty ? null : proximasParcelas.first;
+    final parcelasAtrasadas = debtTransactions.where((t) => t.status == 'overdue').length;
+
+    final projetosEmAndamento = projects.where((p) => p.status == 'active').length;
+    final projetosAtrasados = projects.where((p) {
+      if (p.status == 'completed' || p.status == 'canceled' || p.endDate == null) return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isBefore(now);
+    }).toList();
+
+    final projetosComPrazo = projects.where((p) {
+      if (p.status == 'completed' || p.status == 'canceled' || p.endDate == null) return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isAfter(now);
+    }).toList()
+      ..sort((a, b) => DateTime.parse(a.endDate!).compareTo(DateTime.parse(b.endDate!)));
+
+    final projetoMaisProximo = projetosComPrazo.isEmpty ? null : projetosComPrazo.first;
+    final mediaProgresso = projects.isEmpty ? 0.0 : projects.fold<double>(0, (sum, p) => sum + p.progress) / projects.length;
+
+    final tarefasAtrasadas = tasks.where((t) => t.status == 'atrasada').length;
+    final despesasVencidas = transactions.where((t) => t.type == 'expense' && t.status == 'overdue').length;
+    final parcelasVencidas = debtTransactions.where((t) => t.status == 'overdue').length;
+    final projetosPrazoVencido = projetosAtrasados.length;
+
+    String money(double value) {
+      if (shouldMask) return currency == 'USD' ? '\$ ******' : 'R\$ ******';
+      final prefix = currency == 'USD' ? '\$' : 'R\$';
+      return '$prefix ${value.toStringAsFixed(2)}';
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('DiasOrganize', style: TextStyle(fontWeight: FontWeight.bold)),
+        actions: [
+          if (visualLock)
+            IconButton(
+              icon: Icon(_temporaryUnlock ? Icons.lock_open : Icons.lock),
+              tooltip: _temporaryUnlock ? 'Ocultar valores' : 'Revelar valores',
+              onPressed: () => setState(() => _temporaryUnlock = !_temporaryUnlock),
+            ),
+        ],
+      ),
+      drawer: const AppDrawer(),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          GridView.count(
+            crossAxisCount: 2,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            childAspectRatio: 1.1,
+            children: [
+              _DashboardSummaryCard(
+                title: 'Financeiro do mês',
+                icon: Icons.account_balance_wallet,
+                color: Colors.blue,
+                lines: [
+                  'Receitas: ${money(receitasMes)}',
+                  'Despesas: ${money(despesasMes)}',
+                  'Previsto: ${money(saldoPrevisto)}',
+                  'Realizado: ${money(saldoRealizado)}',
+                ],
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const FinanceScreen())),
+              ),
+              _DashboardSummaryCard(
+                title: 'Dívidas',
+                icon: Icons.money_off,
+                color: Colors.deepOrange,
+                lines: [
+                  'Total: ${money(totalDividas)}',
+                  'Restante: ${money(valorRestante)}',
+                  'Próxima: ${proximaParcela?.dueDate != null ? DateFormat('dd/MM').format(DateTime.parse(proximaParcela!.dueDate!)) : '-'}',
+                  'Atrasadas: $parcelasAtrasadas',
+                ],
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const DebtsScreen())),
+              ),
+              if (showProjectsCard)
+                _DashboardSummaryCard(
+                  title: 'Projetos',
+                  icon: Icons.rocket_launch,
+                  color: Colors.purple,
+                  lines: [
+                    'Em andamento: $projetosEmAndamento',
+                    'Atrasados: ${projetosAtrasados.length}',
+                    'Prazo mais próximo: ${projetoMaisProximo?.name ?? '-'}',
+                    'Média progresso: ${mediaProgresso.toStringAsFixed(0)}%',
+                  ],
+                  onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const ProjectsScreen())),
+                ),
+              _DashboardSummaryCard(
+                title: 'Alertas',
+                icon: Icons.warning_amber,
+                color: Colors.red,
+                lines: [
+                  'Tarefas atrasadas: $tarefasAtrasadas',
+                  'Despesas vencidas: $despesasVencidas',
+                  'Parcelas vencidas: $parcelasVencidas',
+                  'Projetos vencidos: $projetosPrazoVencido',
+                ],
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const TaskListScreen())),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Tarefas de hoje', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              if (todayTasks.isNotEmpty) Text('${todayTasks.length} tarefa(s)'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (todayTasks.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(child: Text('Nenhuma tarefa para hoje! 🎉')),
+            )
+          else
+            ...todayTasks.map((t) => Card(
+                  margin: const EdgeInsets.only(bottom: 8),
+                  child: ListTile(
+                    title: Text(t.title, style: TextStyle(decoration: t.status == 'concluida' ? TextDecoration.lineThrough : null)),
+                    subtitle: Text('${t.priority.toUpperCase()} - ${t.status}'),
+                    trailing: Icon(
+                      t.status == 'concluida' ? Icons.check_circle : Icons.circle_outlined,
+                      color: t.status == 'concluida' ? Colors.green : Colors.grey,
+                    ),
+                    onTap: () {
+                      ref.read(tasksProvider.notifier).updateTask(
+                            t.copyWith(
+                              status: t.status == 'concluida' ? 'pendente' : 'concluida',
+                              updatedAt: DateTime.now().toIso8601String(),
+                            ),
+                          );
+                    },
+                  ),
+                )),
+        ],
+      ),
+    );
+  }
+}
+
+class _DashboardSummaryCard extends StatelessWidget {
   final String title;
-  final int count;
+  final List<String> lines;
+  final IconData icon;
   final Color color;
-  const _StatCard({required this.title, required this.count, required this.color});
+  final VoidCallback onTap;
+
+  const _DashboardSummaryCard({
+    required this.title,
+    required this.lines,
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: Container(
-        width: 100,
-        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          gradient: LinearGradient(colors: [color.withOpacity(0.8), color]),
-        ),
-        child: Column(
-          children: [
-            Text(count.toString(), style: const TextStyle(fontSize: 26, fontWeight: FontWeight.bold, color: Colors.white)),
-            Text(title, style: const TextStyle(fontSize: 12, color: Colors.white), textAlign: TextAlign.center, overflow: TextOverflow.ellipsis),
-          ],
+      elevation: 1,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, color: color, size: 18),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13), overflow: TextOverflow.ellipsis),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              ...lines.map((line) => Padding(
+                    padding: const EdgeInsets.only(bottom: 2),
+                    child: Text(line, maxLines: 1, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 11)),
+                  )),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -6,36 +6,15 @@ import '../tasks/task_list_screen.dart';
 import '../calendar/calendar_screen.dart';
 import '../settings/settings_screen.dart';
 import '../settings/categories_screen.dart';
-import '../statistics/stats_screen.dart';
 import '../finance/finance_screen.dart';
 import '../debts/debts_screen.dart';
 import '../projects/projects_screen.dart';
-import 'app_drawer.dart';
-import 'package:intl/intl.dart';
-
-class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
-
-  @override
-  State<HomeScreen> createState() => _HomeScreenState();
-}
-
-class _HomeScreenState extends State<HomeScreen> {
-  int _currentIndex = 0;
 
   late final List<Widget> _pages = [
-    const TaskDashboard(),
-    const TaskListScreen(),
     const FinanceScreen(),
     const ProjectsScreen(),
     const MoreScreen(),
-  ];
-
-  @override
-  Widget build(BuildContext context) {
     final showFab = _currentIndex == 0 || _currentIndex == 1;
-    return Scaffold(
-      body: _pages[_currentIndex],
       floatingActionButton: showFab
           ? FloatingActionButton(
               onPressed: () {
@@ -47,14 +26,6 @@ class _HomeScreenState extends State<HomeScreen> {
               child: const Icon(Icons.add),
             )
           : null,
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        onTap: (idx) => setState(() => _currentIndex = idx),
-        type: BottomNavigationBarType.fixed,
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Início'),
-          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Tarefas'),
           BottomNavigationBarItem(icon: Icon(Icons.account_balance_wallet), label: 'Finanças'),
           BottomNavigationBarItem(icon: Icon(Icons.rocket_launch), label: 'Projetos'),
           BottomNavigationBarItem(icon: Icon(Icons.menu), label: 'Mais'),
@@ -106,16 +77,8 @@ class MoreScreen extends StatelessWidget {
             title: const Text('Configurações'),
             onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const SettingsScreen())),
           ),
-        ],
-      ),
-    );
-  }
-}
 
 class TaskDashboard extends ConsumerStatefulWidget {
-  const TaskDashboard({super.key});
-
-  @override
   ConsumerState<TaskDashboard> createState() => _TaskDashboardState();
 }
 
@@ -125,11 +88,218 @@ class _TaskDashboardState extends ConsumerState<TaskDashboard> {
   @override
   Widget build(BuildContext context) {
     final ref = this.ref;
-    final tasks = ref.watch(tasksProvider);
-    final transactions = ref.watch(transactionsProvider);
     final projects = ref.watch(projectsProvider);
     final debts = ref.watch(debtsProvider);
     final appSettings = ref.watch(appSettingsProvider);
+
+    final currency = appSettings[AppSettingKeys.defaultCurrency] ?? 'BRL';
+    final showFinancial = (appSettings[AppSettingKeys.homeShowFinancialValues] ?? 'true') == 'true';
+    final privacyHide = (appSettings[AppSettingKeys.privacyHideHomeValues] ?? 'false') == 'true';
+    final discreteMode = (appSettings[AppSettingKeys.financeDiscreteMode] ?? 'false') == 'true';
+    final visualLock = (appSettings[AppSettingKeys.financeVisualLock] ?? 'false') == 'true';
+    final showProjectsCard = (appSettings[AppSettingKeys.homeShowProjectsCard] ?? 'true') == 'true';
+    final shouldMask = !showFinancial || privacyHide || discreteMode || (visualLock && !_temporaryUnlock);
+
+    final now = DateTime.now();
+    final todayStr = DateFormat('yyyy-MM-dd').format(now);
+
+
+    final monthTransactions = transactions.where((t) {
+      final dt = DateTime.tryParse(t.transactionDate);
+      return dt != null && dt.year == now.year && dt.month == now.month && t.status != 'canceled';
+    }).toList();
+
+    final receitasMes = monthTransactions.where((t) => t.type == 'income').fold<double>(0, (sum, t) => sum + t.amount);
+    final despesasMes = monthTransactions.where((t) => t.type == 'expense').fold<double>(0, (sum, t) => sum + t.amount);
+    final saldoPrevisto = receitasMes - despesasMes;
+
+    final receitasRealizadas = monthTransactions.where((t) => t.type == 'income' && t.status == 'paid').fold<double>(0, (sum, t) => sum + t.amount);
+    final despesasRealizadas = monthTransactions.where((t) => t.type == 'expense' && t.status == 'paid').fold<double>(0, (sum, t) => sum + t.amount);
+    final saldoRealizado = receitasRealizadas - despesasRealizadas;
+
+    final debtTransactions = transactions.where((t) => t.debtId != null && t.status != 'canceled').toList();
+    final totalDividas = debts.where((d) => d.status != 'paid' && d.status != 'canceled').fold<double>(0, (sum, d) => sum + d.totalAmount);
+    final pagoDividas = debtTransactions.where((t) => t.status == 'paid' && t.type == 'expense').fold<double>(0, (sum, t) => sum + t.amount);
+    final valorRestante = (totalDividas - pagoDividas).clamp(0, double.infinity);
+
+    final proximasParcelas = debtTransactions.where((t) {
+      final due = t.dueDate == null ? null : DateTime.tryParse(t.dueDate!);
+      return due != null && due.isAfter(now) && t.status != 'paid';
+    }).toList()
+      ..sort((a, b) => DateTime.parse(a.dueDate!).compareTo(DateTime.parse(b.dueDate!)));
+
+    final proximaParcela = proximasParcelas.isEmpty ? null : proximasParcelas.first;
+    final parcelasAtrasadas = debtTransactions.where((t) => t.status == 'overdue').length;
+
+    final projetosEmAndamento = projects.where((p) => p.status == 'active').length;
+    final projetosAtrasados = projects.where((p) {
+      if (p.status == 'completed' || p.status == 'canceled' || p.endDate == null) return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isBefore(now);
+    }).toList();
+
+    final projetosComPrazo = projects.where((p) {
+      if (p.status == 'completed' || p.status == 'canceled' || p.endDate == null) return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isAfter(now);
+    }).toList()
+      ..sort((a, b) => DateTime.parse(a.endDate!).compareTo(DateTime.parse(b.endDate!)));
+
+    final projetoMaisProximo = projetosComPrazo.isEmpty ? null : projetosComPrazo.first;
+    final mediaProgresso = projects.isEmpty ? 0.0 : projects.fold<double>(0, (sum, p) => sum + p.progress) / projects.length;
+
+    final tarefasAtrasadas = tasks.where((t) => t.status == 'atrasada').length;
+    final despesasVencidas = transactions.where((t) => t.type == 'expense' && t.status == 'overdue').length;
+    final parcelasVencidas = debtTransactions.where((t) => t.status == 'overdue').length;
+    final projetosPrazoVencido = projetosAtrasados.length;
+
+    String money(double value) {
+      if (shouldMask) return currency == 'USD' ? '\$ ******' : 'R\$ ******';
+      final prefix = currency == 'USD' ? '\$' : 'R\$';
+      return '$prefix ${value.toStringAsFixed(2)}';
+        actions: [
+          if (visualLock)
+            IconButton(
+              icon: Icon(_temporaryUnlock ? Icons.lock_open : Icons.lock),
+              tooltip: _temporaryUnlock ? 'Ocultar valores' : 'Revelar valores',
+              onPressed: () => setState(() => _temporaryUnlock = !_temporaryUnlock),
+            ),
+        ],
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          GridView.count(
+            crossAxisCount: 2,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            childAspectRatio: 1.1,
+            children: [
+              _DashboardSummaryCard(
+                title: 'Financeiro do mês',
+                icon: Icons.account_balance_wallet,
+                color: Colors.blue,
+                lines: [
+                  'Receitas: ${money(receitasMes)}',
+                  'Despesas: ${money(despesasMes)}',
+                  'Previsto: ${money(saldoPrevisto)}',
+                  'Realizado: ${money(saldoRealizado)}',
+                ],
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const FinanceScreen())),
+              _DashboardSummaryCard(
+                title: 'Dívidas',
+                icon: Icons.money_off,
+                color: Colors.deepOrange,
+                lines: [
+                  'Total: ${money(totalDividas)}',
+                  'Restante: ${money(valorRestante)}',
+                  'Próxima: ${proximaParcela?.dueDate != null ? DateFormat('dd/MM').format(DateTime.parse(proximaParcela!.dueDate!)) : '-'}',
+                  'Atrasadas: $parcelasAtrasadas',
+                ],
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const DebtsScreen())),
+              ),
+              if (showProjectsCard)
+                _DashboardSummaryCard(
+                  title: 'Projetos',
+                  icon: Icons.rocket_launch,
+                  color: Colors.purple,
+                  lines: [
+                    'Em andamento: $projetosEmAndamento',
+                    'Atrasados: ${projetosAtrasados.length}',
+                    'Prazo mais próximo: ${projetoMaisProximo?.name ?? '-'}',
+                    'Média progresso: ${mediaProgresso.toStringAsFixed(0)}%',
+                  ],
+                  onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const ProjectsScreen())),
+                ),
+              _DashboardSummaryCard(
+                title: 'Alertas',
+                icon: Icons.warning_amber,
+                color: Colors.red,
+                lines: [
+                  'Tarefas atrasadas: $tarefasAtrasadas',
+                  'Despesas vencidas: $despesasVencidas',
+                  'Parcelas vencidas: $parcelasVencidas',
+                  'Projetos vencidos: $projetosPrazoVencido',
+                ],
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const TaskListScreen())),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('Tarefas de hoje', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              if (todayTasks.isNotEmpty) Text('${todayTasks.length} tarefa(s)'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (todayTasks.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 24),
+              child: Center(child: Text('Nenhuma tarefa para hoje! 🎉')),
+            )
+          else
+            ...todayTasks.map((t) => Card(
+                  margin: const EdgeInsets.only(bottom: 8),
+                  child: ListTile(
+                    title: Text(t.title, style: TextStyle(decoration: t.status == 'concluida' ? TextDecoration.lineThrough : null)),
+                    subtitle: Text('${t.priority.toUpperCase()} - ${t.status}'),
+                    trailing: Icon(
+                      t.status == 'concluida' ? Icons.check_circle : Icons.circle_outlined,
+                      color: t.status == 'concluida' ? Colors.green : Colors.grey,
+                    onTap: () {
+                      ref.read(tasksProvider.notifier).updateTask(
+                            t.copyWith(
+                              status: t.status == 'concluida' ? 'pendente' : 'concluida',
+                              updatedAt: DateTime.now().toIso8601String(),
+                            ),
+                          );
+                    },
+                  ),
+                )),
+        ],
+}
+
+class _DashboardSummaryCard extends StatelessWidget {
+  final List<String> lines;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  const _DashboardSummaryCard({
+    required this.title,
+    required this.lines,
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+  @override
+      elevation: 1,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, color: color, size: 18),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13), overflow: TextOverflow.ellipsis),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              ...lines.map((line) => Padding(
+                    padding: const EdgeInsets.only(bottom: 2),
+                    child: Text(line, maxLines: 1, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 11)),
+                  )),
+            ],
+          ),
 
     final currency = appSettings[AppSettingKeys.defaultCurrency] ?? 'BRL';
     final showFinancial = (appSettings[AppSettingKeys.homeShowFinancialValues] ?? 'true') == 'true';

--- a/lib/features/debts/create_debt_screen.dart
+++ b/lib/features/debts/create_debt_screen.dart
@@ -28,10 +28,15 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
   int? _selectedCategoryId;
 
    bool _generateInstallments = false;
+   bool _remindInstallments = false;
 
   @override
   void initState() {
     super.initState();
+    if (widget.debt == null) {
+      final settings = ref.read(appSettingsProvider);
+      _remindInstallments = (settings[AppSettingKeys.debtsRemindersDefault] ?? 'false') == 'true';
+    }
     if (widget.debt != null) {
       _nameController.text = widget.debt!.name;
       _descriptionController.text = widget.debt!.description ?? '';
@@ -170,6 +175,12 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
                    value: _generateInstallments,
                    onChanged: (v) => setState(() => _generateInstallments = v),
                  ),
+                 SwitchListTile(
+                   title: const Text('Lembrar parcelas automaticamente?'),
+                   subtitle: const Text('Agenda lembrete local para vencimento de cada parcela'),
+                   value: _remindInstallments,
+                   onChanged: (v) => setState(() => _remindInstallments = v),
+                 ),
                  const SizedBox(height: 16),
                ],
                OutlinedButton.icon(
@@ -297,6 +308,7 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
               transactionDate: due.toIso8601String(),
               dueDate: due.toIso8601String(),
               status: 'pending',
+              reminderEnabled: _remindInstallments,
               isFixed: false,
               recurrenceType: 'none',
               debtId: id,
@@ -316,4 +328,3 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
     if (mounted) Navigator.pop(context);
   }
 }
-

--- a/lib/features/debts/create_debt_screen.dart
+++ b/lib/features/debts/create_debt_screen.dart
@@ -29,6 +29,11 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
 
    bool _generateInstallments = false;
    bool _remindInstallments = false;
+    if (widget.debt == null) {
+      final settings = ref.read(appSettingsProvider);
+      _remindInstallments = (settings[AppSettingKeys.debtsRemindersDefault] ?? 'false') == 'true';
+    }
+   bool _remindInstallments = false;
 
   @override
   void initState() {
@@ -145,6 +150,12 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
                   decoration: const InputDecoration(labelText: 'Categoria Financeira', border: OutlineInputBorder()),
                   value: _selectedCategoryId,
                   items: [
+                 SwitchListTile(
+                   title: const Text('Lembrar parcelas automaticamente?'),
+                   subtitle: const Text('Agenda lembrete local para vencimento de cada parcela'),
+                   value: _remindInstallments,
+                   onChanged: (v) => setState(() => _remindInstallments = v),
+                 ),
                     const DropdownMenuItem<int>(value: null, child: Text('Selecione uma categoria (Obrigatório)')),
                     ...categories.map((c) => DropdownMenuItem(value: c.id, child: Text(c.name)))
                   ],
@@ -273,7 +284,7 @@ class _CreateDebtScreenState extends ConsumerState<CreateDebtScreen> {
        if (confirm != true) return;
     }
 
-    final debt = Debt(
+              reminderEnabled: _remindInstallments,
       id: widget.debt?.id,
       name: name,
       totalAmount: amount,

--- a/lib/features/debts/debts_screen.dart
+++ b/lib/features/debts/debts_screen.dart
@@ -20,6 +20,8 @@ class _DebtsScreenState extends ConsumerState<DebtsScreen> {
   Widget build(BuildContext context) {
     final debts = ref.watch(debtsProvider);
     final transactions = ref.watch(transactionsProvider);
+    final appSettings = ref.watch(appSettingsProvider);
+    final showPaidDebts = (appSettings[AppSettingKeys.debtsShowPaid] ?? 'true') == 'true';
 
     double totalDividas = 0;
     double totalPago = 0;
@@ -101,6 +103,10 @@ class _DebtsScreenState extends ConsumerState<DebtsScreen> {
        final Debt d = ds['debt'];
        final remaining = ds['remainingAmount'] as double;
        final isPaidOut = remaining <= 0;
+
+       if (!showPaidDebts && (d.status == 'paid' || isPaidOut) && _currentFilter != 'quitadas') {
+         return false;
+       }
        
        if (_currentFilter == 'todas') return true;
        if (_currentFilter == 'ativas') return d.status == 'active' && !isPaidOut;
@@ -133,7 +139,7 @@ class _DebtsScreenState extends ConsumerState<DebtsScreen> {
                          _buildFilterChip('Todas', 'todas'),
                          _buildFilterChip('Ativas', 'ativas'),
                          _buildFilterChip('Atrasadas', 'atrasadas'),
-                         _buildFilterChip('Quitadas', 'quitadas'),
+                         if (showPaidDebts) _buildFilterChip('Quitadas', 'quitadas'),
                          _buildFilterChip('Pausadas', 'pausadas'),
                        ],
                      ),

--- a/lib/features/debts/debts_screen.dart
+++ b/lib/features/debts/debts_screen.dart
@@ -22,6 +22,8 @@ class _DebtsScreenState extends ConsumerState<DebtsScreen> {
     final transactions = ref.watch(transactionsProvider);
     final appSettings = ref.watch(appSettingsProvider);
     final showPaidDebts = (appSettings[AppSettingKeys.debtsShowPaid] ?? 'true') == 'true';
+    final appSettings = ref.watch(appSettingsProvider);
+    final showPaidDebts = (appSettings[AppSettingKeys.debtsShowPaid] ?? 'true') == 'true';
 
     double totalDividas = 0;
     double totalPago = 0;
@@ -76,7 +78,11 @@ class _DebtsScreenState extends ConsumerState<DebtsScreen> {
                if (nextDueDate == null) nextDueDate = due;
             } else {
                if (nextDueDate == null) nextDueDate = due;
-            }
+
+       if (!showPaidDebts && (d.status == 'paid' || isPaidOut) && _currentFilter != 'quitadas') {
+         return false;
+       }
+                         if (showPaidDebts) _buildFilterChip('Quitadas', 'quitadas'),
           }
         }
       }

--- a/lib/features/finance/create_transaction_screen.dart
+++ b/lib/features/finance/create_transaction_screen.dart
@@ -27,6 +27,7 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
   bool _isFixed = false;
   String _recurrenceType = 'none';
   int? _categoryId;
+  bool _reminderEnabled = false;
 
   // Available Payment Methods
   final List<String> _paymentMethods = [
@@ -63,6 +64,7 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
         _paidDate = DateTime.parse(widget.transaction!.paidDate!);
       }
       _status = widget.transaction!.status;
+      _reminderEnabled = widget.transaction!.reminderEnabled;
       _isFixed = widget.transaction!.isFixed;
       _recurrenceType = widget.transaction!.recurrenceType;
       _categoryId = widget.transaction!.categoryId;
@@ -172,6 +174,12 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
                   )
                 ],
               ),
+              SwitchListTile(
+                title: const Text('Ativar lembrete local'),
+                subtitle: const Text('Para vencimento/receita prevista'),
+                value: _reminderEnabled,
+                onChanged: (_dueDate != null || _type == 'income') ? (v) => setState(() => _reminderEnabled = v) : null,
+              ),
               const SizedBox(height: 16),
               DropdownButtonFormField<int>(
                 value: _categoryId,
@@ -259,6 +267,7 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
                       categoryId: _categoryId,
                       paymentMethod: _selectedPaymentMethod,
                       status: _status,
+                      reminderEnabled: _reminderEnabled,
                       isFixed: _isFixed,
                       recurrenceType: _recurrenceType,
                       notes: _notesController.text.isNotEmpty ? _notesController.text : null,

--- a/lib/features/finance/create_transaction_screen.dart
+++ b/lib/features/finance/create_transaction_screen.dart
@@ -28,6 +28,8 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
   String _recurrenceType = 'none';
   int? _categoryId;
   bool _reminderEnabled = false;
+      _reminderEnabled = widget.transaction!.reminderEnabled;
+  bool _reminderEnabled = false;
 
   // Available Payment Methods
   final List<String> _paymentMethods = [
@@ -147,6 +149,12 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
                      border: const OutlineInputBorder(),
                      hintText: _type == 'expense' ? 'Desconto por pagar antecipado' : 'Desconto concedido',
                    ),
+              SwitchListTile(
+                title: const Text('Ativar lembrete local'),
+                subtitle: const Text('Para vencimento/receita prevista'),
+                value: _reminderEnabled,
+                onChanged: (_dueDate != null || _type == 'income') ? (v) => setState(() => _reminderEnabled = v) : null,
+              ),
                    keyboardType: const TextInputType.numberWithOptions(decimal: true),
                  ),
               ],
@@ -234,6 +242,7 @@ class _CreateTransactionScreenState extends ConsumerState<CreateTransactionScree
                 },
               ),
               const SizedBox(height: 16),
+                      reminderEnabled: _reminderEnabled,
               TextField(
                 controller: _notesController,
                 decoration: const InputDecoration(labelText: 'Observações (Opcional)', border: OutlineInputBorder()),

--- a/lib/features/projects/create_project_screen.dart
+++ b/lib/features/projects/create_project_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../domain/providers.dart';
 import '../../data/models/project_model.dart';
-
 class CreateProjectScreen extends ConsumerStatefulWidget {
   final Project? project;
 
@@ -17,11 +16,92 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
   final _nameController = TextEditingController();
   final _descriptionController = TextEditingController();
   final _notesController = TextEditingController();
-  
-  DateTime? _startDate;
-  DateTime? _endDate;
-  String _status = 'active';
   String _priority = 'media';
+  String _color = '0xFF2196F3';
+  String _icon = 'rocket_launch';
+  bool _reminderEnabled = false;
+      _notesController.text = widget.project!.notes ?? '';
+      _priority = widget.project!.priority;
+      _color = widget.project!.color;
+      _icon = widget.project!.icon;
+      _reminderEnabled = widget.project!.reminderEnabled;
+              decoration: const InputDecoration(labelText: 'Título *', border: OutlineInputBorder()),
+            TextField(
+              controller: _notesController,
+              decoration: const InputDecoration(labelText: 'Observações (Opcional)', border: OutlineInputBorder()),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 16),
+               decoration: const InputDecoration(labelText: 'Status *', border: OutlineInputBorder()),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+               decoration: const InputDecoration(labelText: 'Prioridade *', border: OutlineInputBorder()),
+               value: _priority,
+               items: const [
+                 DropdownMenuItem(value: 'baixa', child: Text('Baixa')),
+                 DropdownMenuItem(value: 'media', child: Text('Média')),
+                 DropdownMenuItem(value: 'alta', child: Text('Alta')),
+               ],
+               onChanged: (val) {
+                 if (val != null) setState(() => _priority = val);
+               },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              decoration: const InputDecoration(labelText: 'Cor', border: OutlineInputBorder()),
+              value: _color,
+              items: const [
+                DropdownMenuItem(value: '0xFF2196F3', child: Text('Azul')),
+                DropdownMenuItem(value: '0xFF4CAF50', child: Text('Verde')),
+                DropdownMenuItem(value: '0xFFFF9800', child: Text('Laranja')),
+                DropdownMenuItem(value: '0xFFE91E63', child: Text('Rosa')),
+                DropdownMenuItem(value: '0xFF9C27B0', child: Text('Roxo')),
+              ],
+              onChanged: (val) {
+                if (val != null) setState(() => _color = val);
+              },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              decoration: const InputDecoration(labelText: 'Ícone', border: OutlineInputBorder()),
+              value: _icon,
+              items: const [
+                DropdownMenuItem(value: 'rocket_launch', child: Text('Foguete')),
+                DropdownMenuItem(value: 'work', child: Text('Trabalho')),
+                DropdownMenuItem(value: 'school', child: Text('Estudo')),
+                DropdownMenuItem(value: 'build', child: Text('Construção')),
+                DropdownMenuItem(value: 'lightbulb', child: Text('Ideia')),
+              ],
+              onChanged: (val) {
+                if (val != null) setState(() => _icon = val);
+              },
+            ),
+            SwitchListTile(
+              title: const Text('Ativar lembrete de prazo'),
+              subtitle: const Text('Lembrete local para o prazo final do projeto'),
+              value: _reminderEnabled,
+              onChanged: _endDate != null ? (v) => setState(() => _reminderEnabled = v) : null,
+            ),
+     final title = _nameController.text.trim();
+     if (title.isEmpty) {
+       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Título é obrigatório.')));
+       return;
+     }
+
+     if (_startDate != null && _endDate != null && _endDate!.isBefore(_startDate!)) {
+       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Prazo final não pode ser anterior à data de início.')));
+     final String? completedAt = _status == 'completed'
+        ? (widget.project?.completedAt ?? DateTime.now().toIso8601String())
+        : null;
+
+        name: title,
+        notes: _notesController.text.isNotEmpty ? _notesController.text : null,
+        completedAt: completedAt,
+        progress: _status == 'completed' ? 100 : (widget.project?.progress ?? 0),
+        reminderEnabled: _reminderEnabled,
+        priority: _priority,
+        color: _color,
+        icon: _icon,
   String _color = '0xFF2196F3';
   String _icon = 'rocket_launch';
   bool _reminderEnabled = false;

--- a/lib/features/projects/create_project_screen.dart
+++ b/lib/features/projects/create_project_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../domain/providers.dart';
 import '../../data/models/project_model.dart';
-import '../../data/database/db_helper.dart';
 
 class CreateProjectScreen extends ConsumerStatefulWidget {
   final Project? project;
@@ -17,10 +16,15 @@ class CreateProjectScreen extends ConsumerStatefulWidget {
 class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
   final _nameController = TextEditingController();
   final _descriptionController = TextEditingController();
+  final _notesController = TextEditingController();
   
   DateTime? _startDate;
   DateTime? _endDate;
   String _status = 'active';
+  String _priority = 'media';
+  String _color = '0xFF2196F3';
+  String _icon = 'rocket_launch';
+  bool _reminderEnabled = false;
 
   @override
   void initState() {
@@ -28,7 +32,12 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
     if (widget.project != null) {
       _nameController.text = widget.project!.name;
       _descriptionController.text = widget.project!.description ?? '';
+      _notesController.text = widget.project!.notes ?? '';
       _status = widget.project!.status;
+      _priority = widget.project!.priority;
+      _color = widget.project!.color;
+      _icon = widget.project!.icon;
+      _reminderEnabled = widget.project!.reminderEnabled;
       if (widget.project!.startDate != null) {
         _startDate = DateTime.parse(widget.project!.startDate!);
       }
@@ -53,12 +62,18 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
           children: [
             TextField(
               controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Nome do Projeto', border: OutlineInputBorder()),
+              decoration: const InputDecoration(labelText: 'Título *', border: OutlineInputBorder()),
             ),
             const SizedBox(height: 16),
             TextField(
               controller: _descriptionController,
               decoration: const InputDecoration(labelText: 'Descrição (Opcional)', border: OutlineInputBorder()),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _notesController,
+              decoration: const InputDecoration(labelText: 'Observações (Opcional)', border: OutlineInputBorder()),
               maxLines: 3,
             ),
             const SizedBox(height: 16),
@@ -99,7 +114,7 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
             ),
             const SizedBox(height: 16),
             DropdownButtonFormField<String>(
-               decoration: const InputDecoration(labelText: 'Status', border: OutlineInputBorder()),
+               decoration: const InputDecoration(labelText: 'Status *', border: OutlineInputBorder()),
                value: _status,
                items: const [
                  DropdownMenuItem(value: 'active', child: Text('Ativo')),
@@ -110,6 +125,55 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
                onChanged: (val) {
                  if (val != null) setState(() => _status = val);
                },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+               decoration: const InputDecoration(labelText: 'Prioridade *', border: OutlineInputBorder()),
+               value: _priority,
+               items: const [
+                 DropdownMenuItem(value: 'baixa', child: Text('Baixa')),
+                 DropdownMenuItem(value: 'media', child: Text('Média')),
+                 DropdownMenuItem(value: 'alta', child: Text('Alta')),
+               ],
+               onChanged: (val) {
+                 if (val != null) setState(() => _priority = val);
+               },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              decoration: const InputDecoration(labelText: 'Cor', border: OutlineInputBorder()),
+              value: _color,
+              items: const [
+                DropdownMenuItem(value: '0xFF2196F3', child: Text('Azul')),
+                DropdownMenuItem(value: '0xFF4CAF50', child: Text('Verde')),
+                DropdownMenuItem(value: '0xFFFF9800', child: Text('Laranja')),
+                DropdownMenuItem(value: '0xFFE91E63', child: Text('Rosa')),
+                DropdownMenuItem(value: '0xFF9C27B0', child: Text('Roxo')),
+              ],
+              onChanged: (val) {
+                if (val != null) setState(() => _color = val);
+              },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              decoration: const InputDecoration(labelText: 'Ícone', border: OutlineInputBorder()),
+              value: _icon,
+              items: const [
+                DropdownMenuItem(value: 'rocket_launch', child: Text('Foguete')),
+                DropdownMenuItem(value: 'work', child: Text('Trabalho')),
+                DropdownMenuItem(value: 'school', child: Text('Estudo')),
+                DropdownMenuItem(value: 'build', child: Text('Construção')),
+                DropdownMenuItem(value: 'lightbulb', child: Text('Ideia')),
+              ],
+              onChanged: (val) {
+                if (val != null) setState(() => _icon = val);
+              },
+            ),
+            SwitchListTile(
+              title: const Text('Ativar lembrete de prazo'),
+              subtitle: const Text('Lembrete local para o prazo final do projeto'),
+              value: _reminderEnabled,
+              onChanged: _endDate != null ? (v) => setState(() => _reminderEnabled = v) : null,
             ),
             const SizedBox(height: 32),
             ElevatedButton(
@@ -124,19 +188,35 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
   }
 
   void _saveProject() {
-     final name = _nameController.text.trim();
-     if (name.isEmpty) {
-       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Por favor, informe o nome do projeto.')));
+     final title = _nameController.text.trim();
+     if (title.isEmpty) {
+       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Título é obrigatório.')));
        return;
      }
 
+     if (_startDate != null && _endDate != null && _endDate!.isBefore(_startDate!)) {
+       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Prazo final não pode ser anterior à data de início.')));
+       return;
+     }
+
+     final String? completedAt = _status == 'completed'
+        ? (widget.project?.completedAt ?? DateTime.now().toIso8601String())
+        : null;
+
      final project = Project(
         id: widget.project?.id,
-        name: name,
+        name: title,
         description: _descriptionController.text.isNotEmpty ? _descriptionController.text : null,
         startDate: _startDate?.toIso8601String(),
         endDate: _endDate?.toIso8601String(),
         status: _status,
+        notes: _notesController.text.isNotEmpty ? _notesController.text : null,
+        completedAt: completedAt,
+        progress: _status == 'completed' ? 100 : (widget.project?.progress ?? 0),
+        reminderEnabled: _reminderEnabled,
+        priority: _priority,
+        color: _color,
+        icon: _icon,
         createdAt: widget.project?.createdAt ?? DateTime.now().toIso8601String(),
         updatedAt: DateTime.now().toIso8601String(),
      );

--- a/lib/features/projects/project_details_screen.dart
+++ b/lib/features/projects/project_details_screen.dart
@@ -3,33 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/providers.dart';
 import '../../data/models/project_model.dart';
 import '../../data/models/project_step_model.dart';
-import 'create_project_screen.dart';
 import '../tasks/create_task_screen.dart';
 
-class ProjectDetailsScreen extends ConsumerStatefulWidget {
-  final Project project;
-
-  const ProjectDetailsScreen({super.key, required this.project});
-
-  @override
-  ConsumerState<ProjectDetailsScreen> createState() => _ProjectDetailsScreenState();
-}
-
-class _ProjectDetailsScreenState extends ConsumerState<ProjectDetailsScreen> {
-  @override
-  Widget build(BuildContext context) {
-    final projects = ref.watch(projectsProvider);
-    final pIndex = projects.indexWhere((p) => p.id == widget.project.id);
-
-    if (pIndex == -1) {
       return Scaffold(
         appBar: AppBar(title: const Text('Projeto não encontrado')),
         body: const Center(child: Text('Este projeto foi excluído.')),
       );
-    }
-
     final project = projects[pIndex];
-    final allTasks = ref.watch(tasksProvider);
     final projectTasks = allTasks.where((t) => t.projectId == project.id && t.status != 'canceled').toList();
     final steps = project.id == null ? <ProjectStep>[] : ref.watch(projectStepsProvider(project.id!));
 
@@ -37,7 +17,6 @@ class _ProjectDetailsScreenState extends ConsumerState<ProjectDetailsScreen> {
     final progress = (project.progress / 100).clamp(0.0, 1.0);
     final daysRemaining = _daysRemaining(project.endDate);
 
-    return Scaffold(
       appBar: AppBar(title: const Text('Detalhes do Projeto')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
@@ -76,6 +55,292 @@ class _ProjectDetailsScreenState extends ConsumerState<ProjectDetailsScreen> {
             Card(
               child: Padding(
                 padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Progresso geral: ${project.progress.toInt()}%'),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(value: progress, minHeight: 8),
+                    const SizedBox(height: 8),
+                    Text('Tarefas concluídas: $doneTasks/${projectTasks.length}'),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 3: Etapas'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: project.id == null ? null : () => _showAddStepDialog(project.id!),
+                      icon: const Icon(Icons.playlist_add),
+                      label: const Text('Adicionar etapa'),
+                    ),
+                    const SizedBox(height: 8),
+                    if (steps.isEmpty)
+                      const Text('Nenhuma etapa criada.')
+                    else
+                      ...steps.map((step) => ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            leading: const Icon(Icons.flag_outlined),
+                            title: Text(step.title),
+                            subtitle: Text('Status: ${step.status}'),
+                          )),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 4: Tarefas'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: () {
+                        Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTaskScreen(projectId: project.id)));
+                      },
+                      icon: const Icon(Icons.add_task),
+                      label: const Text('Adicionar tarefa'),
+                    ),
+                    const SizedBox(height: 8),
+                    if (projectTasks.isEmpty)
+                      const Text('Nenhuma tarefa vinculada.')
+                    else
+                      ...projectTasks.map((t) {
+                        final isCompleted = t.status == 'concluida';
+                        return CheckboxListTile(
+                          contentPadding: EdgeInsets.zero,
+                          value: isCompleted,
+                          title: Text(
+                            t.title,
+                            style: TextStyle(decoration: isCompleted ? TextDecoration.lineThrough : null),
+                          ),
+                          subtitle: Text(t.date ?? 'Sem data'),
+                          onChanged: (val) {
+                            if (val == null) return;
+                            final updated = t.copyWith(status: val ? 'concluida' : 'pendente');
+                            ref.read(tasksProvider.notifier).updateTask(updated);
+                            if (val) _maybeSuggestCompleteProject(project.id, project.status);
+                          },
+                        );
+                      }),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 5: Ações'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    OutlinedButton.icon(
+                      onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (_) => CreateProjectScreen(project: project))),
+                      icon: const Icon(Icons.edit),
+                      label: const Text('Editar projeto'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: project.status == 'completed' ? null : () => _updateStatus(project, 'completed'),
+                      icon: const Icon(Icons.check_circle_outline),
+                      label: const Text('Concluir projeto'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: project.status == 'paused' ? null : () => _updateStatus(project, 'paused'),
+                      icon: const Icon(Icons.pause_circle_outline),
+                      label: const Text('Pausar projeto'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: _confirmDelete,
+                      icon: const Icon(Icons.delete_outline, color: Colors.red),
+                      label: const Text('Excluir projeto', style: TextStyle(color: Colors.red)),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(title, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+    );
+  }
+
+  Widget _infoChip(String text) {
+    return Chip(label: Text(text));
+  }
+
+  String _statusLabel(String status) {
+    switch (status) {
+      case 'active':
+        return 'Em andamento';
+      case 'paused':
+        return 'Pausado';
+      case 'completed':
+        return 'Concluído';
+      default:
+        return status;
+    }
+  }
+
+  String _priorityLabel(String priority) {
+    switch (priority) {
+      case 'alta':
+        return 'Alta';
+      case 'baixa':
+        return 'Baixa';
+      default:
+        return 'Média';
+    }
+  }
+
+  String _dateLabel(String? isoDate) {
+    if (isoDate == null) return '—';
+    final dt = DateTime.tryParse(isoDate);
+    if (dt == null) return '—';
+    return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+  }
+
+  int? _daysRemaining(String? endDate) {
+    if (endDate == null) return null;
+    final end = DateTime.tryParse(endDate);
+    if (end == null) return null;
+    return end.difference(DateTime.now()).inDays;
+  }
+
+  Future<void> _updateStatus(Project project, String status) async {
+    final completedAt = status == 'completed' ? (project.completedAt ?? DateTime.now().toIso8601String()) : null;
+    await ref.read(projectsProvider.notifier).updateProject(
+          project.copyWith(
+            status: status,
+            completedAt: completedAt,
+            clearCompletedAt: status != 'completed',
+            progress: status == 'completed' ? 100 : project.progress,
+            updatedAt: DateTime.now().toIso8601String(),
+          ),
+        );
+    if (project.id != null && status != 'paused' && status != 'completed') {
+      await ref.read(projectsProvider.notifier).recalculateProgress(project.id!);
+    }
+  }
+
+  void _showAddStepDialog(int projectId) {
+    final controller = TextEditingController();
+    DateTime? dueDate;
+    bool remind = false;
+    showDialog(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setLocalState) => AlertDialog(
+        title: const Text('Adicionar etapa'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: controller,
+              decoration: const InputDecoration(hintText: 'Título da etapa'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed: () async {
+                final dt = await showDatePicker(
+                  context: context,
+                  initialDate: dueDate ?? DateTime.now(),
+                  firstDate: DateTime(2000),
+                  lastDate: DateTime(2100),
+                );
+                if (dt != null) setLocalState(() => dueDate = dt);
+              },
+              icon: const Icon(Icons.event),
+              label: Text(dueDate == null ? 'Definir prazo (opcional)' : 'Prazo: ${_dateLabel(dueDate!.toIso8601String())}'),
+            ),
+            SwitchListTile(
+              title: const Text('Lembrete de prazo'),
+              value: remind,
+              onChanged: dueDate != null ? (v) => setLocalState(() => remind = v) : null,
+            )
+          ],
+        ),
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancelar')),
+          TextButton(
+            onPressed: () async {
+              final title = controller.text.trim();
+              if (title.isEmpty) return;
+              await ref.read(projectStepsProvider(projectId).notifier).addStep(
+                title,
+                dueDate: dueDate?.toIso8601String(),
+                reminderEnabled: remind,
+              );
+              Navigator.pop(ctx);
+            child: const Text('Adicionar'),
+      )),
+        content: const Text('O que deseja fazer com as tarefas vinculadas a este projeto?'),
+              if (widget.project.id != null) {
+                ref.read(projectsProvider.notifier).removeProject(widget.project.id!, deleteLinkedTasks: false);
+              }
+              Navigator.pop(ctx);
+              Navigator.pop(context);
+            },
+            child: const Text('Manter tarefas (desvincular)'),
+          ),
+          TextButton(
+            onPressed: () {
+              if (widget.project.id != null) {
+                ref.read(projectsProvider.notifier).removeProject(widget.project.id!, deleteLinkedTasks: true);
+              }
+              Navigator.pop(ctx);
+              Navigator.pop(context);
+            },
+            child: const Text('Excluir tarefas vinculadas', style: TextStyle(color: Colors.red)),
+      ),
+    );
+  }
+
+  void _maybeSuggestCompleteProject(int? projectId, String currentProjectStatus) {
+    if (projectId == null || currentProjectStatus == 'completed') return;
+    final allTasks = ref.read(tasksProvider);
+    final projectTasks = allTasks.where((t) => t.projectId == projectId).toList();
+    final allCompleted = projectTasks.isNotEmpty && projectTasks.every((t) => t.status == 'concluida');
+    if (!allCompleted) return;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Projeto pronto para conclusão'),
+        content: const Text('Todas as tarefas deste projeto foram concluídas. Deseja marcar o projeto como concluído?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Agora não')),
+          TextButton(
+            onPressed: () {
+              final projects = ref.read(projectsProvider);
+              final idx = projects.indexWhere((p) => p.id == projectId);
+              if (idx != -1) {
+                _updateStatus(projects[idx], 'completed');
+              }
+              Navigator.pop(ctx);
+            },
+            child: const Text('Marcar como concluído'),
+          ),
+        ],
+      ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [

--- a/lib/features/projects/project_details_screen.dart
+++ b/lib/features/projects/project_details_screen.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/providers.dart';
 import '../../data/models/project_model.dart';
+import '../../data/models/project_step_model.dart';
 import 'create_project_screen.dart';
-import '../tasks/create_task_screen.dart'; // We should probably pass project to CreateTaskScreen
+import '../tasks/create_task_screen.dart';
 
 class ProjectDetailsScreen extends ConsumerStatefulWidget {
   final Project project;
@@ -19,79 +20,303 @@ class _ProjectDetailsScreenState extends ConsumerState<ProjectDetailsScreen> {
   Widget build(BuildContext context) {
     final projects = ref.watch(projectsProvider);
     final pIndex = projects.indexWhere((p) => p.id == widget.project.id);
-    
-    if (pIndex == -1) {
-       return Scaffold(
-         appBar: AppBar(title: const Text('Projeto não encontrado')),
-         body: const Center(child: Text('Este projeto foi excluído.')),
-       );
-    }
-    final project = projects[pIndex];
 
+    if (pIndex == -1) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Projeto não encontrado')),
+        body: const Center(child: Text('Este projeto foi excluído.')),
+      );
+    }
+
+    final project = projects[pIndex];
     final allTasks = ref.watch(tasksProvider);
-    final projectTasks = allTasks.where((t) => t.projectId == project.id).toList();
+    final projectTasks = allTasks.where((t) => t.projectId == project.id && t.status != 'canceled').toList();
+    final steps = project.id == null ? <ProjectStep>[] : ref.watch(projectStepsProvider(project.id!));
+
+    final doneTasks = projectTasks.where((t) => t.status == 'concluida').length;
+    final progress = (project.progress / 100).clamp(0.0, 1.0);
+    final daysRemaining = _daysRemaining(project.endDate);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(project.name),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.edit),
-            onPressed: () {
-              Navigator.push(context, MaterialPageRoute(builder: (_) => CreateProjectScreen(project: project)));
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.delete),
-            onPressed: () => _confirmDelete(),
-          )
-        ],
-      ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () {
-          // Pass the preset projectId down to create task
-          Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTaskScreen(projectId: project.id)));
-        },
-        icon: const Icon(Icons.add_task),
-        label: const Text('Nova Tarefa'),
-      ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-           if (project.description != null && project.description!.isNotEmpty)
-              Padding(
-                 padding: const EdgeInsets.all(16.0),
-                 child: Text(project.description!, style: const TextStyle(fontSize: 16)),
+      appBar: AppBar(title: const Text('Detalhes do Projeto')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _sectionTitle('Seção 1: Resumo do projeto'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(project.name, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    Text(project.description?.isNotEmpty == true ? project.description! : 'Sem descrição.'),
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        _infoChip('Status: ${_statusLabel(project.status)}'),
+                        _infoChip('Prioridade: ${_priorityLabel(project.priority)}'),
+                        _infoChip('Início: ${_dateLabel(project.startDate)}'),
+                        _infoChip('Prazo: ${_dateLabel(project.endDate)}'),
+                        _infoChip(daysRemaining == null ? 'Dias restantes: —' : 'Dias restantes: $daysRemaining'),
+                      ],
+                    ),
+                  ],
+                ),
               ),
-           const Divider(),
-           const Padding(
-             padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-             child: Text('Tarefas do Projeto', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-           ),
-           Expanded(
-             child: projectTasks.isEmpty 
-               ? const Center(child: Text('Nenhuma tarefa vinculada a este projeto.'))
-               : ListView.builder(
-                   itemCount: projectTasks.length,
-                   itemBuilder: (context, index) {
-                      final t = projectTasks[index];
-                      bool isCompleted = t.status == 'concluida';
-                      return CheckboxListTile(
-                        title: Text(t.title, style: TextStyle(decoration: isCompleted ? TextDecoration.lineThrough : null)),
-                        subtitle: t.date != null ? Text(t.date!) : null,
-                        value: isCompleted,
-                        onChanged: (val) {
-                           if (val != null) {
-                              final updated = t.copyWith(status: val ? 'concluida' : 'pendente');
-                              ref.read(tasksProvider.notifier).updateTask(updated);
-                           }
-                        },
-                      );
-                   },
-                 ),
-           )
-        ],
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 2: Progresso'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Progresso geral: ${project.progress.toInt()}%'),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(value: progress, minHeight: 8),
+                    const SizedBox(height: 8),
+                    Text('Tarefas concluídas: $doneTasks/${projectTasks.length}'),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 3: Etapas'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: project.id == null ? null : () => _showAddStepDialog(project.id!),
+                      icon: const Icon(Icons.playlist_add),
+                      label: const Text('Adicionar etapa'),
+                    ),
+                    const SizedBox(height: 8),
+                    if (steps.isEmpty)
+                      const Text('Nenhuma etapa criada.')
+                    else
+                      ...steps.map((step) => ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            leading: const Icon(Icons.flag_outlined),
+                            title: Text(step.title),
+                            subtitle: Text('Status: ${step.status}'),
+                          )),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 4: Tarefas'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: () {
+                        Navigator.push(context, MaterialPageRoute(builder: (_) => CreateTaskScreen(projectId: project.id)));
+                      },
+                      icon: const Icon(Icons.add_task),
+                      label: const Text('Adicionar tarefa'),
+                    ),
+                    const SizedBox(height: 8),
+                    if (projectTasks.isEmpty)
+                      const Text('Nenhuma tarefa vinculada.')
+                    else
+                      ...projectTasks.map((t) {
+                        final isCompleted = t.status == 'concluida';
+                        return CheckboxListTile(
+                          contentPadding: EdgeInsets.zero,
+                          value: isCompleted,
+                          title: Text(
+                            t.title,
+                            style: TextStyle(decoration: isCompleted ? TextDecoration.lineThrough : null),
+                          ),
+                          subtitle: Text(t.date ?? 'Sem data'),
+                          onChanged: (val) {
+                            if (val == null) return;
+                            final updated = t.copyWith(status: val ? 'concluida' : 'pendente');
+                            ref.read(tasksProvider.notifier).updateTask(updated);
+                            if (val) _maybeSuggestCompleteProject(project.id, project.status);
+                          },
+                        );
+                      }),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            _sectionTitle('Seção 5: Ações'),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    OutlinedButton.icon(
+                      onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (_) => CreateProjectScreen(project: project))),
+                      icon: const Icon(Icons.edit),
+                      label: const Text('Editar projeto'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: project.status == 'completed' ? null : () => _updateStatus(project, 'completed'),
+                      icon: const Icon(Icons.check_circle_outline),
+                      label: const Text('Concluir projeto'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: project.status == 'paused' ? null : () => _updateStatus(project, 'paused'),
+                      icon: const Icon(Icons.pause_circle_outline),
+                      label: const Text('Pausar projeto'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: _confirmDelete,
+                      icon: const Icon(Icons.delete_outline, color: Colors.red),
+                      label: const Text('Excluir projeto', style: TextStyle(color: Colors.red)),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(title, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+    );
+  }
+
+  Widget _infoChip(String text) {
+    return Chip(label: Text(text));
+  }
+
+  String _statusLabel(String status) {
+    switch (status) {
+      case 'active':
+        return 'Em andamento';
+      case 'paused':
+        return 'Pausado';
+      case 'completed':
+        return 'Concluído';
+      default:
+        return status;
+    }
+  }
+
+  String _priorityLabel(String priority) {
+    switch (priority) {
+      case 'alta':
+        return 'Alta';
+      case 'baixa':
+        return 'Baixa';
+      default:
+        return 'Média';
+    }
+  }
+
+  String _dateLabel(String? isoDate) {
+    if (isoDate == null) return '—';
+    final dt = DateTime.tryParse(isoDate);
+    if (dt == null) return '—';
+    return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+  }
+
+  int? _daysRemaining(String? endDate) {
+    if (endDate == null) return null;
+    final end = DateTime.tryParse(endDate);
+    if (end == null) return null;
+    return end.difference(DateTime.now()).inDays;
+  }
+
+  Future<void> _updateStatus(Project project, String status) async {
+    final completedAt = status == 'completed' ? (project.completedAt ?? DateTime.now().toIso8601String()) : null;
+    await ref.read(projectsProvider.notifier).updateProject(
+          project.copyWith(
+            status: status,
+            completedAt: completedAt,
+            clearCompletedAt: status != 'completed',
+            progress: status == 'completed' ? 100 : project.progress,
+            updatedAt: DateTime.now().toIso8601String(),
+          ),
+        );
+    if (project.id != null && status != 'paused' && status != 'completed') {
+      await ref.read(projectsProvider.notifier).recalculateProgress(project.id!);
+    }
+  }
+
+  void _showAddStepDialog(int projectId) {
+    final controller = TextEditingController();
+    DateTime? dueDate;
+    bool remind = false;
+    showDialog(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setLocalState) => AlertDialog(
+        title: const Text('Adicionar etapa'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: controller,
+              decoration: const InputDecoration(hintText: 'Título da etapa'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed: () async {
+                final dt = await showDatePicker(
+                  context: context,
+                  initialDate: dueDate ?? DateTime.now(),
+                  firstDate: DateTime(2000),
+                  lastDate: DateTime(2100),
+                );
+                if (dt != null) setLocalState(() => dueDate = dt);
+              },
+              icon: const Icon(Icons.event),
+              label: Text(dueDate == null ? 'Definir prazo (opcional)' : 'Prazo: ${_dateLabel(dueDate!.toIso8601String())}'),
+            ),
+            SwitchListTile(
+              title: const Text('Lembrete de prazo'),
+              value: remind,
+              onChanged: dueDate != null ? (v) => setLocalState(() => remind = v) : null,
+            )
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancelar')),
+          TextButton(
+            onPressed: () async {
+              final title = controller.text.trim();
+              if (title.isEmpty) return;
+              await ref.read(projectStepsProvider(projectId).notifier).addStep(
+                title,
+                dueDate: dueDate?.toIso8601String(),
+                reminderEnabled: remind,
+              );
+              Navigator.pop(ctx);
+            },
+            child: const Text('Adicionar'),
+          ),
+        ],
+      )),
     );
   }
 
@@ -100,21 +325,61 @@ class _ProjectDetailsScreenState extends ConsumerState<ProjectDetailsScreen> {
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Excluir Projeto'),
-        content: const Text('Deseja excluir este projeto? O projeto será removido das tarefas associadas.'),
+        content: const Text('O que deseja fazer com as tarefas vinculadas a este projeto?'),
         actions: [
           TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancelar')),
           TextButton(
             onPressed: () {
-               if (widget.project.id != null) {
-                  ref.read(projectsProvider.notifier).removeProject(widget.project.id!);
-               }
-               Navigator.pop(ctx);
-               Navigator.pop(context);
-            }, 
-            child: const Text('Excluir', style: TextStyle(color: Colors.red)),
+              if (widget.project.id != null) {
+                ref.read(projectsProvider.notifier).removeProject(widget.project.id!, deleteLinkedTasks: false);
+              }
+              Navigator.pop(ctx);
+              Navigator.pop(context);
+            },
+            child: const Text('Manter tarefas (desvincular)'),
+          ),
+          TextButton(
+            onPressed: () {
+              if (widget.project.id != null) {
+                ref.read(projectsProvider.notifier).removeProject(widget.project.id!, deleteLinkedTasks: true);
+              }
+              Navigator.pop(ctx);
+              Navigator.pop(context);
+            },
+            child: const Text('Excluir tarefas vinculadas', style: TextStyle(color: Colors.red)),
           )
         ],
-      )
+      ),
+    );
+  }
+
+  void _maybeSuggestCompleteProject(int? projectId, String currentProjectStatus) {
+    if (projectId == null || currentProjectStatus == 'completed') return;
+    final allTasks = ref.read(tasksProvider);
+    final projectTasks = allTasks.where((t) => t.projectId == projectId).toList();
+    final allCompleted = projectTasks.isNotEmpty && projectTasks.every((t) => t.status == 'concluida');
+    if (!allCompleted) return;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Projeto pronto para conclusão'),
+        content: const Text('Todas as tarefas deste projeto foram concluídas. Deseja marcar o projeto como concluído?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Agora não')),
+          TextButton(
+            onPressed: () {
+              final projects = ref.read(projectsProvider);
+              final idx = projects.indexWhere((p) => p.id == projectId);
+              if (idx != -1) {
+                _updateStatus(projects[idx], 'completed');
+              }
+              Navigator.pop(ctx);
+            },
+            child: const Text('Marcar como concluído'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/projects/projects_screen.dart
+++ b/lib/features/projects/projects_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import '../../domain/providers.dart';
 import '../../data/models/project_model.dart';
 import 'create_project_screen.dart';
@@ -14,10 +13,22 @@ class ProjectsScreen extends ConsumerStatefulWidget {
 }
 
 class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
+  String _quickFilter = 'all';
+
   @override
   Widget build(BuildContext context) {
     final projects = ref.watch(projectsProvider);
     final tasks = ref.watch(tasksProvider);
+    final appSettings = ref.watch(appSettingsProvider);
+    final showCompleted = (appSettings[AppSettingKeys.projectsShowCompleted] ?? 'true') == 'true';
+    final showPaused = (appSettings[AppSettingKeys.projectsShowPaused] ?? 'true') == 'true';
+    final defaultSort = appSettings[AppSettingKeys.projectsDefaultSort] ?? 'created_desc';
+
+    final filteredProjects = projects.where((p) => _matchesQuickFilter(p, showCompleted: showCompleted, showPaused: showPaused)).toList();
+    _applySort(filteredProjects, defaultSort);
+    final inProgressCount = projects.where((p) => _matchesQuickFilter(p, forcedFilter: 'in_progress')).length;
+    final completedCount = projects.where((p) => p.status == 'completed').length;
+    final overdueCount = projects.where((p) => _matchesQuickFilter(p, forcedFilter: 'overdue')).length;
 
     return Scaffold(
       appBar: AppBar(
@@ -30,121 +41,336 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
         icon: const Icon(Icons.add),
         label: const Text('Novo Projeto'),
       ),
-      body: projects.isEmpty
-          ? const Center(
-              child: Text(
-                'Nenhum projeto cadastrado.\nQue tal começar um novo objetivo?',
-                textAlign: TextAlign.center,
-                style: TextStyle(color: Colors.grey, fontSize: 16),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          GridView.count(
+            crossAxisCount: 2,
+            childAspectRatio: 1.7,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            children: [
+              _buildSummaryCard('Total de Projetos', projects.length.toString(), Icons.folder_copy, Colors.blue),
+              _buildSummaryCard('Em andamento', inProgressCount.toString(), Icons.play_circle_fill, Colors.orange),
+              _buildSummaryCard('Concluídos', completedCount.toString(), Icons.check_circle, Colors.green),
+              _buildSummaryCard('Atrasados', overdueCount.toString(), Icons.warning_amber, Colors.red),
+            ],
+          ),
+          const SizedBox(height: 18),
+          const Text('Filtros rápidos', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 40,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                _buildQuickFilter('all', 'Todos'),
+                _buildQuickFilter('planned', 'Planejados'),
+                _buildQuickFilter('in_progress', 'Em andamento'),
+                if (showPaused) _buildQuickFilter('paused', 'Pausados'),
+                if (showCompleted) _buildQuickFilter('completed', 'Concluídos'),
+                _buildQuickFilter('overdue', 'Atrasados'),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          const Text('Lista de Projetos', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          if (filteredProjects.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 28),
+              child: Center(
+                child: Text(
+                  'Nenhum projeto encontrado para os filtros atuais.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.grey, fontSize: 16),
+                ),
               ),
             )
-          : ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: projects.length,
-              itemBuilder: (context, index) {
-                final project = projects[index];
-                
-                // Calculate progress
-                final projectTasks = tasks.where((t) => t.projectId == project.id).toList();
-                final completedTasks = projectTasks.where((t) => t.status == 'concluida').length;
-                final progress = projectTasks.isEmpty ? 0.0 : completedTasks / projectTasks.length;
+          else
+            ...filteredProjects.map((project) {
+              final projectTasks = tasks.where((t) => t.projectId == project.id && t.status != 'canceled').toList();
+              final completedTasks = projectTasks.where((t) => t.status == 'concluida').length;
+              final progress = (project.progress / 100).clamp(0.0, 1.0);
+              final color = Color(int.parse(project.color));
+              final daysRemaining = _getDaysRemaining(project.endDate);
+              final dueDateLabel = _formatDueDate(project.endDate);
 
-                return Card(
-                  margin: const EdgeInsets.only(bottom: 12),
-                  elevation: 2,
-                  child: InkWell(
-                    borderRadius: BorderRadius.circular(12),
-                    onTap: () {
-                      Navigator.push(context, MaterialPageRoute(builder: (_) => ProjectDetailsScreen(project: project)));
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                               Expanded(
-                                 child: Text(
-                                   project.name,
-                                   style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                                 ),
-                               ),
-                               _buildStatusBadge(project.status),
-                            ],
-                          ),
-                          if (project.description != null && project.description!.isNotEmpty) ...[
-                            const SizedBox(height: 8),
-                            Text(
-                              project.description!,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(color: Colors.grey.shade600),
+              return Card(
+                margin: const EdgeInsets.only(bottom: 12),
+                elevation: 2,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: () {
+                    Navigator.push(context, MaterialPageRoute(builder: (_) => ProjectDetailsScreen(project: project)));
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            CircleAvatar(
+                              backgroundColor: color.withOpacity(0.1),
+                              child: Icon(_iconFromKey(project.icon), color: color),
                             ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                project.name,
+                                style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                            _buildStatusBadge(project.status),
                           ],
-                          const SizedBox(height: 16),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                               Text('${(progress * 100).toInt()}% Concluído', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12)),
-                               Text('$completedTasks/${projectTasks.length} tarefas', style: const TextStyle(color: Colors.grey, fontSize: 12)),
-                            ],
-                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: _buildPriorityBadge(project.priority),
+                        ),
+                        if (project.description != null && project.description!.isNotEmpty) ...[
                           const SizedBox(height: 8),
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
-                              value: progress,
-                              minHeight: 8,
-                              backgroundColor: Colors.grey.shade200,
-                              color: progress >= 1.0 ? Colors.green : Colors.blue,
-                            ),
+                          Text(
+                            project.description!,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(color: Colors.grey.shade600),
                           ),
                         ],
-                      ),
+                        const SizedBox(height: 8),
+                        Text('Prazo: $dueDateLabel', style: const TextStyle(fontSize: 12)),
+                        if (daysRemaining != null) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            daysRemaining >= 0 ? 'Faltam $daysRemaining dia(s) para o prazo' : 'Prazo expirado há ${daysRemaining.abs()} dia(s)',
+                            style: TextStyle(color: daysRemaining >= 0 ? Colors.teal : Colors.red, fontSize: 12),
+                          ),
+                        ],
+                        const SizedBox(height: 16),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text('${project.progress.toInt()}% Concluído', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12)),
+                            Text('$completedTasks/${projectTasks.length} tarefas', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: progress,
+                            minHeight: 8,
+                            backgroundColor: Colors.grey.shade200,
+                            color: progress >= 1.0 ? Colors.green : Colors.blue,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                );
-              },
-            ),
+                ),
+              );
+            }),
+        ],
+      ),
     );
   }
 
+  Widget _buildSummaryCard(String title, String value, IconData icon, Color color) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Row(
+          children: [
+            CircleAvatar(
+              backgroundColor: color.withOpacity(0.1),
+              child: Icon(icon, color: color),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                  Text(title, style: const TextStyle(fontSize: 12), maxLines: 2),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuickFilter(String value, String label) {
+    final selected = _quickFilter == value;
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: ChoiceChip(
+        label: Text(label),
+        selected: selected,
+        onSelected: (_) => setState(() => _quickFilter = value),
+      ),
+    );
+  }
+
+  bool _matchesQuickFilter(Project project, {String? forcedFilter, bool showCompleted = true, bool showPaused = true}) {
+    final filter = forcedFilter ?? _quickFilter;
+    if (!showCompleted && project.status == 'completed' && filter != 'completed') return false;
+    if (!showPaused && project.status == 'paused' && filter != 'paused') return false;
+    final isOverdue = _isOverdue(project);
+    final startDate = project.startDate == null ? null : DateTime.tryParse(project.startDate!);
+    final isPlanned = startDate != null && startDate.isAfter(DateTime.now());
+
+    switch (filter) {
+      case 'planned':
+        return isPlanned;
+      case 'in_progress':
+        return project.status == 'active' && !isPlanned && !isOverdue;
+      case 'paused':
+        return project.status == 'paused';
+      case 'completed':
+        return project.status == 'completed';
+      case 'overdue':
+        return isOverdue;
+      default:
+        return true;
+    }
+  }
+
+  void _applySort(List<Project> items, String sort) {
+    switch (sort) {
+      case 'deadline_asc':
+        items.sort((a, b) {
+          final ad = a.endDate == null ? null : DateTime.tryParse(a.endDate!);
+          final bd = b.endDate == null ? null : DateTime.tryParse(b.endDate!);
+          if (ad == null && bd == null) return 0;
+          if (ad == null) return 1;
+          if (bd == null) return -1;
+          return ad.compareTo(bd);
+        });
+        break;
+      case 'progress_desc':
+        items.sort((a, b) => b.progress.compareTo(a.progress));
+        break;
+      case 'name_asc':
+        items.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        break;
+      default:
+        items.sort((a, b) {
+          final ad = DateTime.tryParse(a.createdAt);
+          final bd = DateTime.tryParse(b.createdAt);
+          if (ad == null && bd == null) return 0;
+          if (ad == null) return 1;
+          if (bd == null) return -1;
+          return bd.compareTo(ad);
+        });
+    }
+  }
+
+  bool _isOverdue(Project project) {
+    if (project.endDate == null) return false;
+    if (project.status == 'completed' || project.status == 'canceled') return false;
+    final end = DateTime.tryParse(project.endDate!);
+    if (end == null) return false;
+    return end.isBefore(DateTime.now());
+  }
+
+  int? _getDaysRemaining(String? endDate) {
+    if (endDate == null) return null;
+    final end = DateTime.tryParse(endDate);
+    if (end == null) return null;
+    return end.difference(DateTime.now()).inDays;
+  }
+
+  String _formatDueDate(String? endDate) {
+    if (endDate == null) return 'Sem prazo';
+    final dt = DateTime.tryParse(endDate);
+    if (dt == null) return 'Sem prazo';
+    return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+  }
+
+  IconData _iconFromKey(String key) {
+    switch (key) {
+      case 'work':
+        return Icons.work;
+      case 'school':
+        return Icons.school;
+      case 'build':
+        return Icons.build;
+      case 'lightbulb':
+        return Icons.lightbulb;
+      default:
+        return Icons.rocket_launch;
+    }
+  }
+
   Widget _buildStatusBadge(String status) {
-     Color color;
-     String label;
+    Color color;
+    String label;
 
-     switch (status) {
-        case 'active':
-          color = Colors.blue;
-          label = 'Ativo';
-          break;
-        case 'completed':
-          color = Colors.green;
-          label = 'Concluído';
-          break;
-        case 'paused':
-          color = Colors.orange;
-          label = 'Pausado';
-          break;
-        case 'canceled':
-          color = Colors.red;
-          label = 'Cancelado';
-          break;
-        default:
-          color = Colors.grey;
-          label = status;
-     }
+    switch (status) {
+      case 'active':
+        color = Colors.blue;
+        label = 'Ativo';
+        break;
+      case 'completed':
+        color = Colors.green;
+        label = 'Concluído';
+        break;
+      case 'paused':
+        color = Colors.orange;
+        label = 'Pausado';
+        break;
+      case 'canceled':
+        color = Colors.red;
+        label = 'Cancelado';
+        break;
+      default:
+        color = Colors.grey;
+        label = status;
+    }
 
-     return Container(
-       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-       decoration: BoxDecoration(
-          color: color.withOpacity(0.1),
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: color),
-       ),
-       child: Text(label, style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.bold)),
-     );
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color),
+      ),
+      child: Text(label, style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.bold)),
+    );
+  }
+
+  Widget _buildPriorityBadge(String priority) {
+    Color color;
+    String label;
+    switch (priority) {
+      case 'alta':
+        color = Colors.red;
+        label = 'Alta';
+        break;
+      case 'baixa':
+        color = Colors.green;
+        label = 'Baixa';
+        break;
+      default:
+        color = Colors.orange;
+        label = 'Média';
+    }
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color),
+      ),
+      child: Text('Prioridade: $label', style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.bold)),
+    );
   }
 }

--- a/lib/features/projects/projects_screen.dart
+++ b/lib/features/projects/projects_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../domain/providers.dart';
 import '../../data/models/project_model.dart';
 import 'create_project_screen.dart';
 import 'project_details_screen.dart';
@@ -15,10 +14,6 @@ class ProjectsScreen extends ConsumerStatefulWidget {
 class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
   String _quickFilter = 'all';
 
-  @override
-  Widget build(BuildContext context) {
-    final projects = ref.watch(projectsProvider);
-    final tasks = ref.watch(tasksProvider);
     final appSettings = ref.watch(appSettingsProvider);
     final showCompleted = (appSettings[AppSettingKeys.projectsShowCompleted] ?? 'true') == 'true';
     final showPaused = (appSettings[AppSettingKeys.projectsShowPaused] ?? 'true') == 'true';
@@ -29,18 +24,6 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
     final inProgressCount = projects.where((p) => _matchesQuickFilter(p, forcedFilter: 'in_progress')).length;
     final completedCount = projects.where((p) => p.status == 'completed').length;
     final overdueCount = projects.where((p) => _matchesQuickFilter(p, forcedFilter: 'overdue')).length;
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Projetos'),
-      ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () {
-          Navigator.push(context, MaterialPageRoute(builder: (_) => const CreateProjectScreen()));
-        },
-        icon: const Icon(Icons.add),
-        label: const Text('Novo Projeto'),
-      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
@@ -87,8 +70,6 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
                   textAlign: TextAlign.center,
                   style: TextStyle(color: Colors.grey, fontSize: 16),
                 ),
-              ),
-            )
           else
             ...filteredProjects.map((project) {
               final projectTasks = tasks.where((t) => t.projectId == project.id && t.status != 'canceled').toList();
@@ -114,6 +95,251 @@ class _ProjectsScreenState extends ConsumerState<ProjectsScreen> {
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
+                            CircleAvatar(
+                              backgroundColor: color.withOpacity(0.1),
+                              child: Icon(_iconFromKey(project.icon), color: color),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                project.name,
+                                style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                              ),
+                            _buildStatusBadge(project.status),
+                        ),
+                        const SizedBox(height: 8),
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: _buildPriorityBadge(project.priority),
+                        ),
+                        if (project.description != null && project.description!.isNotEmpty) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            project.description!,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(color: Colors.grey.shade600),
+                        ],
+                        const SizedBox(height: 8),
+                        Text('Prazo: $dueDateLabel', style: const TextStyle(fontSize: 12)),
+                        if (daysRemaining != null) ...[
+                          Text(
+                            daysRemaining >= 0 ? 'Faltam $daysRemaining dia(s) para o prazo' : 'Prazo expirado há ${daysRemaining.abs()} dia(s)',
+                            style: TextStyle(color: daysRemaining >= 0 ? Colors.teal : Colors.red, fontSize: 12),
+                        const SizedBox(height: 16),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text('${project.progress.toInt()}% Concluído', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12)),
+                            Text('$completedTasks/${projectTasks.length} tarefas', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: progress,
+                            minHeight: 8,
+                            backgroundColor: Colors.grey.shade200,
+                            color: progress >= 1.0 ? Colors.green : Colors.blue,
+                          ),
+                        ),
+                      ],
+                ),
+              );
+            }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryCard(String title, String value, IconData icon, Color color) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Row(
+          children: [
+            CircleAvatar(
+              backgroundColor: color.withOpacity(0.1),
+              child: Icon(icon, color: color),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(value, style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                  Text(title, style: const TextStyle(fontSize: 12), maxLines: 2),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuickFilter(String value, String label) {
+    final selected = _quickFilter == value;
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: ChoiceChip(
+        label: Text(label),
+        selected: selected,
+        onSelected: (_) => setState(() => _quickFilter = value),
+      ),
+  bool _matchesQuickFilter(Project project, {String? forcedFilter, bool showCompleted = true, bool showPaused = true}) {
+    final filter = forcedFilter ?? _quickFilter;
+    if (!showCompleted && project.status == 'completed' && filter != 'completed') return false;
+    if (!showPaused && project.status == 'paused' && filter != 'paused') return false;
+    final isOverdue = _isOverdue(project);
+    final startDate = project.startDate == null ? null : DateTime.tryParse(project.startDate!);
+    final isPlanned = startDate != null && startDate.isAfter(DateTime.now());
+
+    switch (filter) {
+      case 'planned':
+        return isPlanned;
+      case 'in_progress':
+        return project.status == 'active' && !isPlanned && !isOverdue;
+      case 'paused':
+        return project.status == 'paused';
+      case 'completed':
+        return project.status == 'completed';
+      case 'overdue':
+        return isOverdue;
+      default:
+        return true;
+    }
+  }
+
+  void _applySort(List<Project> items, String sort) {
+    switch (sort) {
+      case 'deadline_asc':
+        items.sort((a, b) {
+          final ad = a.endDate == null ? null : DateTime.tryParse(a.endDate!);
+          final bd = b.endDate == null ? null : DateTime.tryParse(b.endDate!);
+          if (ad == null && bd == null) return 0;
+          if (ad == null) return 1;
+          if (bd == null) return -1;
+          return ad.compareTo(bd);
+        });
+        break;
+      case 'progress_desc':
+        items.sort((a, b) => b.progress.compareTo(a.progress));
+        break;
+      case 'name_asc':
+        items.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        break;
+      default:
+        items.sort((a, b) {
+          final ad = DateTime.tryParse(a.createdAt);
+          final bd = DateTime.tryParse(b.createdAt);
+          if (ad == null && bd == null) return 0;
+          if (ad == null) return 1;
+          if (bd == null) return -1;
+          return bd.compareTo(ad);
+        });
+    }
+  }
+
+  bool _isOverdue(Project project) {
+    if (project.endDate == null) return false;
+    if (project.status == 'completed' || project.status == 'canceled') return false;
+    final end = DateTime.tryParse(project.endDate!);
+    if (end == null) return false;
+    return end.isBefore(DateTime.now());
+  }
+
+  int? _getDaysRemaining(String? endDate) {
+    if (endDate == null) return null;
+    final end = DateTime.tryParse(endDate);
+    if (end == null) return null;
+    return end.difference(DateTime.now()).inDays;
+  }
+
+  String _formatDueDate(String? endDate) {
+    if (endDate == null) return 'Sem prazo';
+    final dt = DateTime.tryParse(endDate);
+    if (dt == null) return 'Sem prazo';
+    return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+  }
+
+  IconData _iconFromKey(String key) {
+    switch (key) {
+      case 'work':
+        return Icons.work;
+      case 'school':
+        return Icons.school;
+      case 'build':
+        return Icons.build;
+      case 'lightbulb':
+        return Icons.lightbulb;
+      default:
+        return Icons.rocket_launch;
+    }
+  }
+
+    Color color;
+    String label;
+
+    switch (status) {
+      case 'active':
+        color = Colors.blue;
+        label = 'Ativo';
+        break;
+      case 'completed':
+        color = Colors.green;
+        label = 'Concluído';
+        break;
+      case 'paused':
+        color = Colors.orange;
+        label = 'Pausado';
+        break;
+      case 'canceled':
+        color = Colors.red;
+        label = 'Cancelado';
+        break;
+      default:
+        color = Colors.grey;
+        label = status;
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color),
+      ),
+      child: Text(label, style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.bold)),
+    );
+  }
+
+  Widget _buildPriorityBadge(String priority) {
+    Color color;
+    String label;
+    switch (priority) {
+      case 'alta':
+        color = Colors.red;
+        label = 'Alta';
+        break;
+      case 'baixa':
+        color = Colors.green;
+        label = 'Baixa';
+        break;
+      default:
+        color = Colors.orange;
+        label = 'Média';
+    }
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color),
+      ),
+      child: Text('Prioridade: $label', style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.bold)),
+    );
                             CircleAvatar(
                               backgroundColor: color.withOpacity(0.1),
                               child: Icon(_iconFromKey(project.icon), color: color),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -2,12 +2,25 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/providers.dart';
 import 'categories_screen.dart';
+import '../finance/finance_categories_screen.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
+  bool _settingBool(Map<String, String> settings, String key, {bool fallback = false}) {
+    return (settings[key] ?? '$fallback') == 'true';
+  }
+
+  int _settingInt(Map<String, String> settings, String key, {int fallback = 0}) {
+    return int.tryParse(settings[key] ?? '$fallback') ?? fallback;
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final appSettings = ref.watch(appSettingsProvider);
+    final currency = appSettings[AppSettingKeys.defaultCurrency] ?? 'BRL';
+    final projectSort = appSettings[AppSettingKeys.projectsDefaultSort] ?? 'created_desc';
+
     return Scaffold(
       appBar: AppBar(title: const Text('Configurações')),
       body: ListView(
@@ -65,6 +78,197 @@ class SettingsScreen extends ConsumerWidget {
                 )
               );
             },
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Finanças', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          ListTile(
+            leading: const Icon(Icons.category_outlined),
+            title: const Text('Gerenciar categorias financeiras'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const FinanceCategoriesScreen()));
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.currency_exchange),
+            title: const Text('Moeda padrão'),
+            subtitle: Text(currency == 'USD' ? 'Dólar (USD)' : 'Real (BRL)'),
+            trailing: const Icon(Icons.expand_more),
+            onTap: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (ctx) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                      title: const Text('Real (BRL)'),
+                      trailing: currency == 'BRL' ? const Icon(Icons.check, color: Colors.blue) : null,
+                      onTap: () async {
+                        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.defaultCurrency, 'BRL');
+                        Navigator.pop(ctx);
+                      },
+                    ),
+                    ListTile(
+                      title: const Text('Dólar (USD)'),
+                      trailing: currency == 'USD' ? const Icon(Icons.check, color: Colors.blue) : null,
+                      onTap: () async {
+                        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.defaultCurrency, 'USD');
+                        Navigator.pop(ctx);
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.visibility),
+            title: const Text('Exibir valores financeiros na Home'),
+            value: _settingBool(appSettings, AppSettingKeys.homeShowFinancialValues, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.homeShowFinancialValues, '$val'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.delete_forever),
+            title: const Text('Limpar movimentações canceladas'),
+            subtitle: const Text('Remove transações com status cancelado'),
+            onTap: () async {
+              await ref.read(transactionsProvider.notifier).clearCanceledTransactions();
+              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Movimentações canceladas removidas.')));
+            },
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Dívidas', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          SwitchListTile(
+            secondary: const Icon(Icons.payments_outlined),
+            title: const Text('Exibir dívidas quitadas'),
+            value: _settingBool(appSettings, AppSettingKeys.debtsShowPaid, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.debtsShowPaid, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.notifications_active_outlined),
+            title: const Text('Ativar lembretes de parcelas por padrão'),
+            value: _settingBool(appSettings, AppSettingKeys.debtsRemindersDefault),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.debtsRemindersDefault, '$val'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.schedule),
+            title: const Text('Avisar vencimento com antecedência'),
+            subtitle: Text('${_settingInt(appSettings, AppSettingKeys.debtsReminderDaysBefore)} dia(s) antes'),
+            trailing: const Icon(Icons.edit),
+            onTap: () async {
+              final controller = TextEditingController(text: (appSettings[AppSettingKeys.debtsReminderDaysBefore] ?? '0'));
+              await showDialog(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text('Dias de antecedência'),
+                  content: TextField(
+                    controller: controller,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(hintText: 'Ex: 2'),
+                  ),
+                  actions: [
+                    TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancelar')),
+                    TextButton(
+                      onPressed: () async {
+                        final value = int.tryParse(controller.text.trim()) ?? 0;
+                        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.debtsReminderDaysBefore, '${value < 0 ? 0 : value}');
+                        Navigator.pop(ctx);
+                      },
+                      child: const Text('Salvar'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.cleaning_services),
+            title: const Text('Limpar dívidas canceladas'),
+            onTap: () async {
+              await ref.read(debtsProvider.notifier).clearCanceledDebts();
+              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Dívidas canceladas removidas.')));
+            },
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Projetos', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          SwitchListTile(
+            secondary: const Icon(Icons.check_circle_outline),
+            title: const Text('Exibir projetos concluídos'),
+            value: _settingBool(appSettings, AppSettingKeys.projectsShowCompleted, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.projectsShowCompleted, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.pause_circle_outline),
+            title: const Text('Exibir projetos pausados'),
+            value: _settingBool(appSettings, AppSettingKeys.projectsShowPaused, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.projectsShowPaused, '$val'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.sort),
+            title: const Text('Ordenação padrão dos projetos'),
+            subtitle: Text(
+              projectSort == 'deadline_asc'
+                  ? 'Prazo mais próximo'
+                  : projectSort == 'progress_desc'
+                      ? 'Maior progresso'
+                      : projectSort == 'name_asc'
+                          ? 'Nome (A-Z)'
+                          : 'Mais recentes',
+            ),
+            trailing: const Icon(Icons.expand_more),
+            onTap: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (ctx) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _projectSortOption(ctx, ref, projectSort, 'created_desc', 'Mais recentes'),
+                    _projectSortOption(ctx, ref, projectSort, 'deadline_asc', 'Prazo mais próximo'),
+                    _projectSortOption(ctx, ref, projectSort, 'progress_desc', 'Maior progresso'),
+                    _projectSortOption(ctx, ref, projectSort, 'name_asc', 'Nome (A-Z)'),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.dashboard_outlined),
+            title: const Text('Mostrar projetos na Home'),
+            value: _settingBool(appSettings, AppSettingKeys.homeShowProjectsCard, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.homeShowProjectsCard, '$val'),
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Privacidade', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          SwitchListTile(
+            secondary: const Icon(Icons.visibility_off),
+            title: const Text('Ocultar valores financeiros na tela inicial'),
+            value: _settingBool(appSettings, AppSettingKeys.privacyHideHomeValues),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.privacyHideHomeValues, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.shield_moon_outlined),
+            title: const Text('Modo discreto para finanças'),
+            subtitle: const Text('Oculta valores com asteriscos (R\$ ******)'),
+            value: _settingBool(appSettings, AppSettingKeys.financeDiscreteMode),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.financeDiscreteMode, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.lock_outline),
+            title: const Text('Bloqueio visual simples dos valores'),
+            subtitle: const Text('Permite revelar valores na Home com um toque'),
+            value: _settingBool(appSettings, AppSettingKeys.financeVisualLock),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.financeVisualLock, '$val'),
           ),
           const Divider(),
           const Padding(padding: EdgeInsets.all(16), child: Text('Gerenciamento', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
@@ -138,6 +342,17 @@ class SettingsScreen extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _projectSortOption(BuildContext ctx, WidgetRef ref, String selected, String value, String label) {
+    return ListTile(
+      title: Text(label),
+      trailing: selected == value ? const Icon(Icons.check, color: Colors.blue) : null,
+      onTap: () async {
+        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.projectsDefaultSort, value);
+        Navigator.pop(ctx);
+      },
     );
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -3,6 +3,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/providers.dart';
 import 'categories_screen.dart';
 import '../finance/finance_categories_screen.dart';
+  bool _settingBool(Map<String, String> settings, String key, {bool fallback = false}) {
+    return (settings[key] ?? '$fallback') == 'true';
+  }
+
+  int _settingInt(Map<String, String> settings, String key, {int fallback = 0}) {
+    return int.tryParse(settings[key] ?? '$fallback') ?? fallback;
+  }
+
+    final appSettings = ref.watch(appSettingsProvider);
+    final currency = appSettings[AppSettingKeys.defaultCurrency] ?? 'BRL';
+    final projectSort = appSettings[AppSettingKeys.projectsDefaultSort] ?? 'created_desc';
+
+import '../finance/finance_categories_screen.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -42,6 +55,197 @@ class SettingsScreen extends ConsumerWidget {
               ref.watch(themeModeProvider) == ThemeMode.system 
                   ? 'Sistema' 
                   : (ref.watch(themeModeProvider) == ThemeMode.dark ? 'Escuro' : 'Claro')
+          const Padding(padding: EdgeInsets.all(16), child: Text('Finanças', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          ListTile(
+            leading: const Icon(Icons.category_outlined),
+            title: const Text('Gerenciar categorias financeiras'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const FinanceCategoriesScreen()));
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.currency_exchange),
+            title: const Text('Moeda padrão'),
+            subtitle: Text(currency == 'USD' ? 'Dólar (USD)' : 'Real (BRL)'),
+            trailing: const Icon(Icons.expand_more),
+            onTap: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (ctx) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                      title: const Text('Real (BRL)'),
+                      trailing: currency == 'BRL' ? const Icon(Icons.check, color: Colors.blue) : null,
+                      onTap: () async {
+                        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.defaultCurrency, 'BRL');
+                        Navigator.pop(ctx);
+                      },
+                    ),
+                    ListTile(
+                      title: const Text('Dólar (USD)'),
+                      trailing: currency == 'USD' ? const Icon(Icons.check, color: Colors.blue) : null,
+                      onTap: () async {
+                        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.defaultCurrency, 'USD');
+                        Navigator.pop(ctx);
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.visibility),
+            title: const Text('Exibir valores financeiros na Home'),
+            value: _settingBool(appSettings, AppSettingKeys.homeShowFinancialValues, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.homeShowFinancialValues, '$val'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.delete_forever),
+            title: const Text('Limpar movimentações canceladas'),
+            subtitle: const Text('Remove transações com status cancelado'),
+            onTap: () async {
+              await ref.read(transactionsProvider.notifier).clearCanceledTransactions();
+              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Movimentações canceladas removidas.')));
+            },
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Dívidas', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          SwitchListTile(
+            secondary: const Icon(Icons.payments_outlined),
+            title: const Text('Exibir dívidas quitadas'),
+            value: _settingBool(appSettings, AppSettingKeys.debtsShowPaid, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.debtsShowPaid, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.notifications_active_outlined),
+            title: const Text('Ativar lembretes de parcelas por padrão'),
+            value: _settingBool(appSettings, AppSettingKeys.debtsRemindersDefault),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.debtsRemindersDefault, '$val'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.schedule),
+            title: const Text('Avisar vencimento com antecedência'),
+            subtitle: Text('${_settingInt(appSettings, AppSettingKeys.debtsReminderDaysBefore)} dia(s) antes'),
+            trailing: const Icon(Icons.edit),
+            onTap: () async {
+              final controller = TextEditingController(text: (appSettings[AppSettingKeys.debtsReminderDaysBefore] ?? '0'));
+              await showDialog(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text('Dias de antecedência'),
+                  content: TextField(
+                    controller: controller,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(hintText: 'Ex: 2'),
+                  ),
+                  actions: [
+                    TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancelar')),
+                    TextButton(
+                      onPressed: () async {
+                        final value = int.tryParse(controller.text.trim()) ?? 0;
+                        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.debtsReminderDaysBefore, '${value < 0 ? 0 : value}');
+                        Navigator.pop(ctx);
+                      },
+                      child: const Text('Salvar'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.cleaning_services),
+            title: const Text('Limpar dívidas canceladas'),
+            onTap: () async {
+              await ref.read(debtsProvider.notifier).clearCanceledDebts();
+              ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Dívidas canceladas removidas.')));
+            },
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Projetos', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          SwitchListTile(
+            secondary: const Icon(Icons.check_circle_outline),
+            title: const Text('Exibir projetos concluídos'),
+            value: _settingBool(appSettings, AppSettingKeys.projectsShowCompleted, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.projectsShowCompleted, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.pause_circle_outline),
+            title: const Text('Exibir projetos pausados'),
+            value: _settingBool(appSettings, AppSettingKeys.projectsShowPaused, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.projectsShowPaused, '$val'),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.sort),
+            title: const Text('Ordenação padrão dos projetos'),
+            subtitle: Text(
+              projectSort == 'deadline_asc'
+                  ? 'Prazo mais próximo'
+                  : projectSort == 'progress_desc'
+                      ? 'Maior progresso'
+                      : projectSort == 'name_asc'
+                          ? 'Nome (A-Z)'
+                          : 'Mais recentes',
+            ),
+            trailing: const Icon(Icons.expand_more),
+            onTap: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (ctx) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _projectSortOption(ctx, ref, projectSort, 'created_desc', 'Mais recentes'),
+                    _projectSortOption(ctx, ref, projectSort, 'deadline_asc', 'Prazo mais próximo'),
+                    _projectSortOption(ctx, ref, projectSort, 'progress_desc', 'Maior progresso'),
+                    _projectSortOption(ctx, ref, projectSort, 'name_asc', 'Nome (A-Z)'),
+                  ],
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.dashboard_outlined),
+            title: const Text('Mostrar projetos na Home'),
+            value: _settingBool(appSettings, AppSettingKeys.homeShowProjectsCard, fallback: true),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.homeShowProjectsCard, '$val'),
+          ),
+          const Divider(),
+          const Padding(padding: EdgeInsets.all(16), child: Text('Privacidade', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))),
+          SwitchListTile(
+            secondary: const Icon(Icons.visibility_off),
+            title: const Text('Ocultar valores financeiros na tela inicial'),
+            value: _settingBool(appSettings, AppSettingKeys.privacyHideHomeValues),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.privacyHideHomeValues, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.shield_moon_outlined),
+            title: const Text('Modo discreto para finanças'),
+            subtitle: const Text('Oculta valores com asteriscos (R\$ ******)'),
+            value: _settingBool(appSettings, AppSettingKeys.financeDiscreteMode),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.financeDiscreteMode, '$val'),
+          ),
+          const Divider(),
+          SwitchListTile(
+            secondary: const Icon(Icons.lock_outline),
+            title: const Text('Bloqueio visual simples dos valores'),
+            subtitle: const Text('Permite revelar valores na Home com um toque'),
+            value: _settingBool(appSettings, AppSettingKeys.financeVisualLock),
+            onChanged: (val) => ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.financeVisualLock, '$val'),
+          ),
+          const Divider(),
             ),
             trailing: const Icon(Icons.expand_more),
             onTap: () {
@@ -115,6 +319,17 @@ class SettingsScreen extends ConsumerWidget {
                       onTap: () async {
                         await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.defaultCurrency, 'USD');
                         Navigator.pop(ctx);
+
+  Widget _projectSortOption(BuildContext ctx, WidgetRef ref, String selected, String value, String label) {
+    return ListTile(
+      title: Text(label),
+      trailing: selected == value ? const Icon(Icons.check, color: Colors.blue) : null,
+      onTap: () async {
+        await ref.read(appSettingsProvider.notifier).setValue(AppSettingKeys.projectsDefaultSort, value);
+        Navigator.pop(ctx);
+      },
+    );
+  }
                       },
                     ),
                   ],

--- a/lib/features/statistics/stats_screen.dart
+++ b/lib/features/statistics/stats_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/providers.dart';
 
@@ -9,70 +8,198 @@ class StatsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tasks = ref.watch(tasksProvider);
-    final pd = tasks.where((t) => t.status == 'pendente').length;
-    final cd = tasks.where((t) => t.status == 'concluida').length;
-    final ad = tasks.where((t) => t.status == 'atrasada').length;
-    final total = tasks.length;
-    
-    return Scaffold(
-      appBar: AppBar(title: const Text('Estatísticas')),
-      body: total == 0 ? const Center(child: Text('Sem tarefas para analisar.')) : Column(
-        children: [
-          const SizedBox(height: 50),
-          SizedBox(
-            height: 250,
-            child: PieChart(
-              PieChartData(
-                sections: [
-                  PieChartSectionData(
-                    value: pd.toDouble(), 
-                    color: Colors.blue, 
-                    title: 'Pend: $pd',
-                    radius: 80,
-                    titleStyle: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)
-                  ),
-                  PieChartSectionData(
-                    value: cd.toDouble(), 
-                    color: Colors.green, 
-                    title: 'Conc: $cd',
-                    radius: 80,
-                    titleStyle: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)
-                  ),
-                  PieChartSectionData(
-                    value: ad.toDouble(), 
-                    color: Colors.red, 
-                    title: 'Atr: $ad',
-                    radius: 80,
-                    titleStyle: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)
-                  ),
-                ],
-                centerSpaceRadius: 40,
-                sectionsSpace: 2,
-              ),
-            ),
+    final categories = ref.watch(categoriesProvider);
+    final transactions = ref.watch(transactionsProvider);
+    final financialCategories = ref.watch(financialCategoriesProvider);
+    final debts = ref.watch(debtsProvider);
+    final projects = ref.watch(projectsProvider);
+
+    final now = DateTime.now();
+
+    final createdTasks = tasks.length;
+    final completedTasks = tasks.where((t) => t.status == 'concluida').length;
+    final pendingTasks = tasks.where((t) => t.status == 'pendente').length;
+    final overdueTasks = tasks.where((t) => t.status == 'atrasada').length;
+    final completionRate = createdTasks == 0 ? 0.0 : (completedTasks / createdTasks) * 100;
+
+    final categoryCounts = <int, int>{};
+    for (final t in tasks) {
+      if (t.categoryId != null) {
+        categoryCounts[t.categoryId!] = (categoryCounts[t.categoryId!] ?? 0) + 1;
+      }
+    }
+    String topTaskCategory = '-';
+    if (categoryCounts.isNotEmpty) {
+      final topId = categoryCounts.entries.reduce((a, b) => a.value >= b.value ? a : b).key;
+      final idx = categories.indexWhere((c) => c.id == topId);
+      if (idx != -1) topTaskCategory = categories[idx].name;
+    }
+
+    final monthTransactions = transactions.where((t) {
+      final dt = DateTime.tryParse(t.transactionDate);
+      return dt != null && dt.year == now.year && dt.month == now.month && t.status != 'canceled';
+    }).toList();
+
+    final receitasMes = monthTransactions.where((t) => t.type == 'income').fold<double>(0, (s, t) => s + t.amount);
+    final despesasMes = monthTransactions.where((t) => t.type == 'expense').fold<double>(0, (s, t) => s + t.amount);
+    final saldoMes = receitasMes - despesasMes;
+
+    final expenseByCategory = <int, double>{};
+    for (final t in monthTransactions.where((t) => t.type == 'expense')) {
+      if (t.categoryId != null) {
+        expenseByCategory[t.categoryId!] = (expenseByCategory[t.categoryId!] ?? 0) + t.amount;
+      }
+    }
+    String topExpenseCategory = '-';
+    if (expenseByCategory.isNotEmpty) {
+      final topCatId = expenseByCategory.entries.reduce((a, b) => a.value >= b.value ? a : b).key;
+      final idx = financialCategories.indexWhere((c) => c.id == topCatId);
+      if (idx != -1) topExpenseCategory = financialCategories[idx].name;
+    }
+
+    final paymentCounts = <String, int>{};
+    for (final t in monthTransactions) {
+      final method = (t.paymentMethod == null || t.paymentMethod!.isEmpty) ? 'não informado' : t.paymentMethod!;
+      paymentCounts[method] = (paymentCounts[method] ?? 0) + 1;
+    }
+    final mostUsedPayment = paymentCounts.isEmpty ? '-' : paymentCounts.entries.reduce((a, b) => a.value >= b.value ? a : b).key;
+
+    final totalPendente = monthTransactions.where((t) => t.status == 'pending' || t.status == 'overdue').fold<double>(0, (s, t) => s + t.amount);
+    final totalPago = monthTransactions.where((t) => t.status == 'paid').fold<double>(0, (s, t) => s + t.amount);
+
+    final debtTransactions = transactions.where((t) => t.debtId != null && t.status != 'canceled').toList();
+    final totalDividas = debts.where((d) => d.status != 'canceled').fold<double>(0, (s, d) => s + d.totalAmount);
+    final totalJaPago = debtTransactions.where((t) => t.status == 'paid').fold<double>(0, (s, t) => s + t.amount);
+    final totalRestante = (totalDividas - totalJaPago).clamp(0, double.infinity);
+    final percentualQuitado = totalDividas == 0 ? 0.0 : (totalJaPago / totalDividas) * 100;
+    final parcelasPagas = debtTransactions.where((t) => t.status == 'paid').length;
+    final parcelasPendentes = debtTransactions.where((t) => t.status == 'pending').length;
+    final parcelasAtrasadas = debtTransactions.where((t) => t.status == 'overdue').length;
+
+    String debtMaxRemaining = '-';
+    double debtMaxRemainingValue = -1;
+    for (final d in debts.where((d) => d.status != 'canceled')) {
+      final paidForDebt = debtTransactions.where((t) => t.debtId == d.id && t.status == 'paid').fold<double>(0, (s, t) => s + t.amount);
+      final remaining = (d.totalAmount - paidForDebt).clamp(0, double.infinity);
+      if (remaining > debtMaxRemainingValue) {
+        debtMaxRemainingValue = remaining;
+        debtMaxRemaining = d.name;
+      }
+    }
+
+    final projetosCriados = projects.length;
+    final projetosAndamento = projects.where((p) => p.status == 'active').length;
+    final projetosConcluidos = projects.where((p) => p.status == 'completed').length;
+    final projetosPausados = projects.where((p) => p.status == 'paused').length;
+    final projetosAtrasados = projects.where((p) {
+      if (p.endDate == null || p.status == 'completed' || p.status == 'canceled') return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isBefore(now);
+    }).length;
+    final mediaProgresso = projects.isEmpty ? 0.0 : projects.fold<double>(0, (s, p) => s + p.progress) / projects.length;
+
+    String projetoMaisProximo = '-';
+    final withDue = projects.where((p) {
+      if (p.endDate == null || p.status == 'completed' || p.status == 'canceled') return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isAfter(now);
+    }).toList()
+      ..sort((a, b) => DateTime.parse(a.endDate!).compareTo(DateTime.parse(b.endDate!)));
+    if (withDue.isNotEmpty) projetoMaisProximo = withDue.first.name;
+
+    return DefaultTabController(
+      length: 5,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Estatísticas'),
+          bottom: const TabBar(
+            isScrollable: true,
+            tabs: [
+              Tab(text: 'Produtividade'),
+              Tab(text: 'Finanças'),
+              Tab(text: 'Dívidas'),
+              Tab(text: 'Projetos'),
+              Tab(text: 'Resumo geral'),
+            ],
           ),
-          const SizedBox(height: 40),
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Card(
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-              child: Padding(
-                padding: const EdgeInsets.all(24.0),
-                child: Column(
-                  children: [
-                    const Text('Taxa de Conclusão', style: TextStyle(fontSize: 18)),
-                    const SizedBox(height: 10),
-                    Text(
-                      '${((cd / total) * 100).toStringAsFixed(1)}%',
-                      style: const TextStyle(fontSize: 48, fontWeight: FontWeight.bold, color: Colors.green),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          )
-        ],
+        ),
+        body: TabBarView(
+          children: [
+            _StatsList(items: [
+              _Metric('Tarefas criadas', '$createdTasks'),
+              _Metric('Tarefas concluídas', '$completedTasks'),
+              _Metric('Tarefas pendentes', '$pendingTasks'),
+              _Metric('Tarefas atrasadas', '$overdueTasks'),
+              _Metric('Taxa de conclusão', '${completionRate.toStringAsFixed(1)}%'),
+              _Metric('Categoria com mais tarefas', topTaskCategory),
+            ]),
+            _StatsList(items: [
+              _Metric('Receitas do mês', 'R\$ ${receitasMes.toStringAsFixed(2)}'),
+              _Metric('Despesas do mês', 'R\$ ${despesasMes.toStringAsFixed(2)}'),
+              _Metric('Saldo do mês', 'R\$ ${saldoMes.toStringAsFixed(2)}'),
+              _Metric('Categoria com maior gasto', topExpenseCategory),
+              _Metric('Forma de pagamento mais usada', mostUsedPayment),
+              _Metric('Total pendente', 'R\$ ${totalPendente.toStringAsFixed(2)}'),
+              _Metric('Total pago', 'R\$ ${totalPago.toStringAsFixed(2)}'),
+            ]),
+            _StatsList(items: [
+              _Metric('Total em dívidas', 'R\$ ${totalDividas.toStringAsFixed(2)}'),
+              _Metric('Total já pago', 'R\$ ${totalJaPago.toStringAsFixed(2)}'),
+              _Metric('Total restante', 'R\$ ${totalRestante.toStringAsFixed(2)}'),
+              _Metric('Percentual quitado', '${percentualQuitado.toStringAsFixed(1)}%'),
+              _Metric('Parcelas pagas', '$parcelasPagas'),
+              _Metric('Parcelas pendentes', '$parcelasPendentes'),
+              _Metric('Parcelas atrasadas', '$parcelasAtrasadas'),
+              _Metric('Dívida com maior valor restante', debtMaxRemaining),
+            ]),
+            _StatsList(items: [
+              _Metric('Projetos criados', '$projetosCriados'),
+              _Metric('Projetos em andamento', '$projetosAndamento'),
+              _Metric('Projetos concluídos', '$projetosConcluidos'),
+              _Metric('Projetos pausados', '$projetosPausados'),
+              _Metric('Projetos atrasados', '$projetosAtrasados'),
+              _Metric('Média de progresso', '${mediaProgresso.toStringAsFixed(1)}%'),
+              _Metric('Projeto mais próximo do prazo', projetoMaisProximo),
+            ]),
+            _StatsList(items: [
+              _Metric('Tarefas totais', '$createdTasks'),
+              _Metric('Saldo do mês', 'R\$ ${saldoMes.toStringAsFixed(2)}'),
+              _Metric('Dívidas restantes', 'R\$ ${totalRestante.toStringAsFixed(2)}'),
+              _Metric('Projetos em andamento', '$projetosAndamento'),
+              _Metric('Média progresso projetos', '${mediaProgresso.toStringAsFixed(1)}%'),
+            ]),
+          ],
+        ),
       ),
+    );
+  }
+}
+
+class _Metric {
+  final String label;
+  final String value;
+  _Metric(this.label, this.value);
+}
+
+class _StatsList extends StatelessWidget {
+  final List<_Metric> items;
+  const _StatsList({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: items.length,
+      itemBuilder: (_, i) {
+        final item = items[i];
+        return Card(
+          margin: const EdgeInsets.only(bottom: 10),
+          child: ListTile(
+            title: Text(item.label),
+            trailing: Text(item.value, style: const TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/statistics/stats_screen.dart
+++ b/lib/features/statistics/stats_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/providers.dart';
 
 class StatsScreen extends ConsumerWidget {
@@ -70,6 +69,134 @@ class StatsScreen extends ConsumerWidget {
     final debtTransactions = transactions.where((t) => t.debtId != null && t.status != 'canceled').toList();
     final totalDividas = debts.where((d) => d.status != 'canceled').fold<double>(0, (s, d) => s + d.totalAmount);
     final totalJaPago = debtTransactions.where((t) => t.status == 'paid').fold<double>(0, (s, t) => s + t.amount);
+    final totalRestante = (totalDividas - totalJaPago).clamp(0, double.infinity);
+    final percentualQuitado = totalDividas == 0 ? 0.0 : (totalJaPago / totalDividas) * 100;
+    final parcelasPagas = debtTransactions.where((t) => t.status == 'paid').length;
+    final parcelasPendentes = debtTransactions.where((t) => t.status == 'pending').length;
+    final parcelasAtrasadas = debtTransactions.where((t) => t.status == 'overdue').length;
+
+    String debtMaxRemaining = '-';
+    double debtMaxRemainingValue = -1;
+    for (final d in debts.where((d) => d.status != 'canceled')) {
+      final paidForDebt = debtTransactions.where((t) => t.debtId == d.id && t.status == 'paid').fold<double>(0, (s, t) => s + t.amount);
+      final remaining = (d.totalAmount - paidForDebt).clamp(0, double.infinity);
+      if (remaining > debtMaxRemainingValue) {
+        debtMaxRemainingValue = remaining;
+        debtMaxRemaining = d.name;
+      }
+    }
+
+    final projetosCriados = projects.length;
+    final projetosAndamento = projects.where((p) => p.status == 'active').length;
+    final projetosConcluidos = projects.where((p) => p.status == 'completed').length;
+    final projetosPausados = projects.where((p) => p.status == 'paused').length;
+    final projetosAtrasados = projects.where((p) {
+      if (p.endDate == null || p.status == 'completed' || p.status == 'canceled') return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isBefore(now);
+    }).length;
+    final mediaProgresso = projects.isEmpty ? 0.0 : projects.fold<double>(0, (s, p) => s + p.progress) / projects.length;
+
+    String projetoMaisProximo = '-';
+    final withDue = projects.where((p) {
+      if (p.endDate == null || p.status == 'completed' || p.status == 'canceled') return false;
+      final end = DateTime.tryParse(p.endDate!);
+      return end != null && end.isAfter(now);
+    }).toList()
+      ..sort((a, b) => DateTime.parse(a.endDate!).compareTo(DateTime.parse(b.endDate!)));
+    if (withDue.isNotEmpty) projetoMaisProximo = withDue.first.name;
+
+    return DefaultTabController(
+      length: 5,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Estatísticas'),
+          bottom: const TabBar(
+            isScrollable: true,
+            tabs: [
+              Tab(text: 'Produtividade'),
+              Tab(text: 'Finanças'),
+              Tab(text: 'Dívidas'),
+              Tab(text: 'Projetos'),
+              Tab(text: 'Resumo geral'),
+            ],
+        ),
+        body: TabBarView(
+          children: [
+            _StatsList(items: [
+              _Metric('Tarefas criadas', '$createdTasks'),
+              _Metric('Tarefas concluídas', '$completedTasks'),
+              _Metric('Tarefas pendentes', '$pendingTasks'),
+              _Metric('Tarefas atrasadas', '$overdueTasks'),
+              _Metric('Taxa de conclusão', '${completionRate.toStringAsFixed(1)}%'),
+              _Metric('Categoria com mais tarefas', topTaskCategory),
+            ]),
+            _StatsList(items: [
+              _Metric('Receitas do mês', 'R\$ ${receitasMes.toStringAsFixed(2)}'),
+              _Metric('Despesas do mês', 'R\$ ${despesasMes.toStringAsFixed(2)}'),
+              _Metric('Saldo do mês', 'R\$ ${saldoMes.toStringAsFixed(2)}'),
+              _Metric('Categoria com maior gasto', topExpenseCategory),
+              _Metric('Forma de pagamento mais usada', mostUsedPayment),
+              _Metric('Total pendente', 'R\$ ${totalPendente.toStringAsFixed(2)}'),
+              _Metric('Total pago', 'R\$ ${totalPago.toStringAsFixed(2)}'),
+            ]),
+            _StatsList(items: [
+              _Metric('Total em dívidas', 'R\$ ${totalDividas.toStringAsFixed(2)}'),
+              _Metric('Total já pago', 'R\$ ${totalJaPago.toStringAsFixed(2)}'),
+              _Metric('Total restante', 'R\$ ${totalRestante.toStringAsFixed(2)}'),
+              _Metric('Percentual quitado', '${percentualQuitado.toStringAsFixed(1)}%'),
+              _Metric('Parcelas pagas', '$parcelasPagas'),
+              _Metric('Parcelas pendentes', '$parcelasPendentes'),
+              _Metric('Parcelas atrasadas', '$parcelasAtrasadas'),
+              _Metric('Dívida com maior valor restante', debtMaxRemaining),
+            ]),
+            _StatsList(items: [
+              _Metric('Projetos criados', '$projetosCriados'),
+              _Metric('Projetos em andamento', '$projetosAndamento'),
+              _Metric('Projetos concluídos', '$projetosConcluidos'),
+              _Metric('Projetos pausados', '$projetosPausados'),
+              _Metric('Projetos atrasados', '$projetosAtrasados'),
+              _Metric('Média de progresso', '${mediaProgresso.toStringAsFixed(1)}%'),
+              _Metric('Projeto mais próximo do prazo', projetoMaisProximo),
+            ]),
+            _StatsList(items: [
+              _Metric('Tarefas totais', '$createdTasks'),
+              _Metric('Saldo do mês', 'R\$ ${saldoMes.toStringAsFixed(2)}'),
+              _Metric('Dívidas restantes', 'R\$ ${totalRestante.toStringAsFixed(2)}'),
+              _Metric('Projetos em andamento', '$projetosAndamento'),
+              _Metric('Média progresso projetos', '${mediaProgresso.toStringAsFixed(1)}%'),
+            ]),
+          ],
+        ),
+
+class _Metric {
+  final String label;
+  final String value;
+  _Metric(this.label, this.value);
+}
+
+class _StatsList extends StatelessWidget {
+  final List<_Metric> items;
+  const _StatsList({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: items.length,
+      itemBuilder: (_, i) {
+        final item = items[i];
+        return Card(
+          margin: const EdgeInsets.only(bottom: 10),
+          child: ListTile(
+            title: Text(item.label),
+            trailing: Text(item.value, style: const TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        );
+      },
+    );
+  }
+}
     final totalRestante = (totalDividas - totalJaPago).clamp(0, double.infinity);
     final percentualQuitado = totalDividas == 0 ? 0.0 : (totalJaPago / totalDividas) * 100;
     final parcelasPagas = debtTransactions.where((t) => t.status == 'paid').length;

--- a/lib/features/tasks/create_task_screen.dart
+++ b/lib/features/tasks/create_task_screen.dart
@@ -24,6 +24,7 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
   String _priority = 'media';
   int? _categoryId;
   int? _projectId;
+  int? _projectStepId;
   bool _hasReminder = false;
 
   @override
@@ -41,6 +42,7 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
       _priority = widget.task!.priority;
       _categoryId = widget.task!.categoryId;
       _projectId = widget.task!.projectId ?? widget.projectId;
+      _projectStepId = widget.task!.projectStepId;
       _hasReminder = widget.task!.reminderEnabled;
     }
   }
@@ -62,6 +64,7 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
       time: _time,
       categoryId: catId!,
       projectId: _projectId,
+      projectStepId: _projectId == null ? null : _projectStepId,
       priority: _priority,
       status: widget.task?.status ?? 'pendente',
       reminderEnabled: _hasReminder,
@@ -205,11 +208,31 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
                      ...projects.map((p) => DropdownMenuItem(value: p.id, child: Text(p.name))),
                    ],
                    onChanged: (val) {
-                     setState(() => _projectId = val);
+                     setState(() {
+                       _projectId = val;
+                       _projectStepId = null;
+                     });
                    },
                  );
               }
             ),
+            if (_projectId != null) ...[
+              const SizedBox(height: 16),
+              Consumer(
+                builder: (context, ref, child) {
+                  final steps = ref.watch(projectStepsProvider(_projectId!));
+                  return DropdownButtonFormField<int>(
+                    value: _projectStepId,
+                    decoration: const InputDecoration(labelText: 'Etapa do Projeto (Opcional)', border: OutlineInputBorder()),
+                    items: [
+                      const DropdownMenuItem<int>(value: null, child: Text('Sem etapa específica')),
+                      ...steps.map((s) => DropdownMenuItem<int>(value: s.id, child: Text(s.title))),
+                    ],
+                    onChanged: (val) => setState(() => _projectStepId = val),
+                  );
+                },
+              ),
+            ],
             const SizedBox(height: 16),
             DropdownButtonFormField<String>(
               value: _priority,

--- a/lib/features/tasks/create_task_screen.dart
+++ b/lib/features/tasks/create_task_screen.dart
@@ -25,6 +25,9 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
   int? _categoryId;
   int? _projectId;
   int? _projectStepId;
+      _projectStepId = widget.task!.projectStepId;
+      projectStepId: _projectId == null ? null : _projectStepId,
+  int? _projectStepId;
   bool _hasReminder = false;
 
   @override
@@ -184,7 +187,27 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
             const SizedBox(height: 16),
             Consumer(
               builder: (context, ref, child) {
-                 final categories = ref.watch(categoriesProvider);
+                     setState(() {
+                       _projectId = val;
+                       _projectStepId = null;
+                     });
+            if (_projectId != null) ...[
+              const SizedBox(height: 16),
+              Consumer(
+                builder: (context, ref, child) {
+                  final steps = ref.watch(projectStepsProvider(_projectId!));
+                  return DropdownButtonFormField<int>(
+                    value: _projectStepId,
+                    decoration: const InputDecoration(labelText: 'Etapa do Projeto (Opcional)', border: OutlineInputBorder()),
+                    items: [
+                      const DropdownMenuItem<int>(value: null, child: Text('Sem etapa específica')),
+                      ...steps.map((s) => DropdownMenuItem<int>(value: s.id, child: Text(s.title))),
+                    ],
+                    onChanged: (val) => setState(() => _projectStepId = val),
+                  );
+                },
+              ),
+            ],
                  if (categories.isEmpty) return const SizedBox.shrink();
                  return DropdownButtonFormField<int>(
                    value: _categoryId ?? categories.first.id,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sqflite: ^2.3.0
   path_provider: ^2.1.2
   path: ^1.9.0
-  intl: ^0.19.0
+  intl: ^0.20.2
   flutter_local_notifications: ^17.1.2
   shared_preferences: ^2.2.2
   fl_chart: ^0.66.0

--- a/test/version2_stability_test.dart
+++ b/test/version2_stability_test.dart
@@ -1,0 +1,450 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:diasorganize/app/theme.dart';
+import 'package:diasorganize/data/models/debt_model.dart';
+import 'package:diasorganize/data/models/project_model.dart';
+import 'package:diasorganize/data/models/project_step_model.dart';
+import 'package:diasorganize/data/models/task_model.dart';
+import 'package:diasorganize/data/models/transaction_model.dart';
+
+class _FinanceStore {
+  int _id = 1;
+  final List<FinancialTransaction> items = [];
+
+  FinancialTransaction create({
+    required String title,
+    required double amount,
+    required String type,
+    required String transactionDate,
+    String status = 'pending',
+    String? dueDate,
+  }) {
+    final tx = FinancialTransaction(
+      id: _id++,
+      title: title,
+      amount: amount,
+      type: type,
+      transactionDate: transactionDate,
+      status: status,
+      dueDate: dueDate,
+      isFixed: false,
+      recurrenceType: 'none',
+      createdAt: DateTime.now().toIso8601String(),
+      updatedAt: DateTime.now().toIso8601String(),
+    );
+    items.add(tx);
+    return tx;
+  }
+
+  void update(FinancialTransaction tx) {
+    final idx = items.indexWhere((e) => e.id == tx.id);
+    if (idx != -1) items[idx] = tx;
+  }
+
+  void delete(int id) {
+    items.removeWhere((e) => e.id == id);
+  }
+}
+
+double _monthTotal(List<FinancialTransaction> items, DateTime ref, String type, {String? status}) {
+  return items.where((t) {
+    final dt = DateTime.parse(t.transactionDate);
+    final monthMatch = dt.year == ref.year && dt.month == ref.month;
+    final typeMatch = t.type == type;
+    final statusMatch = status == null ? true : t.status == status;
+    return monthMatch && typeMatch && statusMatch && t.status != 'canceled';
+  }).fold(0.0, (s, t) => s + t.amount);
+}
+
+double _receitasMes(List<FinancialTransaction> items, DateTime ref) => _monthTotal(items, ref, 'income');
+double _despesasMes(List<FinancialTransaction> items, DateTime ref) => _monthTotal(items, ref, 'expense');
+double _saldoPrevisto(List<FinancialTransaction> items, DateTime ref) => _receitasMes(items, ref) - _despesasMes(items, ref);
+double _saldoRealizado(List<FinancialTransaction> items, DateTime ref) =>
+    _monthTotal(items, ref, 'income', status: 'paid') - _monthTotal(items, ref, 'expense', status: 'paid');
+
+bool _isOverdueExpense(FinancialTransaction t, DateTime now) {
+  if (t.type != 'expense' || t.status == 'paid' || t.status == 'canceled' || t.dueDate == null) return false;
+  final due = DateTime.parse(t.dueDate!);
+  return due.isBefore(now);
+}
+
+List<FinancialTransaction> _generateInstallments({
+  required int debtId,
+  required int count,
+  required double amount,
+  required DateTime firstDueDate,
+}) {
+  return List.generate(count, (i) {
+    final due = DateTime(firstDueDate.year, firstDueDate.month + i, firstDueDate.day);
+    return FinancialTransaction(
+      id: i + 1,
+      title: 'Parcela ${i + 1}/$count',
+      amount: amount,
+      type: 'expense',
+      transactionDate: DateTime(firstDueDate.year, firstDueDate.month, firstDueDate.day).toIso8601String(),
+      dueDate: due.toIso8601String(),
+      debtId: debtId,
+      installmentNumber: i + 1,
+      totalInstallments: count,
+      status: 'pending',
+      isFixed: false,
+      recurrenceType: 'none',
+      createdAt: DateTime.now().toIso8601String(),
+      updatedAt: DateTime.now().toIso8601String(),
+    );
+  });
+}
+
+double _remainingDebt(Debt debt, List<FinancialTransaction> installments) {
+  final paid = installments.where((i) => i.status == 'paid').fold<double>(0, (s, i) => s + i.amount);
+  return (debt.totalAmount - paid).clamp(0, double.infinity);
+}
+
+double _progressDebt(Debt debt, List<FinancialTransaction> installments) {
+  if (debt.totalAmount <= 0) return 0;
+  return ((_remainingDebt(debt, installments) == 0 ? debt.totalAmount : debt.totalAmount - _remainingDebt(debt, installments)) / debt.totalAmount) * 100;
+}
+
+bool _installmentIsOverdue(FinancialTransaction i, DateTime now) {
+  if (i.status == 'paid' || i.status == 'canceled' || i.dueDate == null) return false;
+  return DateTime.parse(i.dueDate!).isBefore(now);
+}
+
+double _projectProgressByTasks(List<Task> tasks) {
+  final valid = tasks.where((t) => t.status != 'canceled').toList();
+  if (valid.isEmpty) return 0;
+  return (valid.where((t) => t.status == 'concluida').length / valid.length) * 100;
+}
+
+double _projectProgressBySteps(List<ProjectStep> steps) {
+  final valid = steps.where((s) => s.status != 'canceled').toList();
+  if (valid.isEmpty) return 0;
+  return (valid.where((s) => s.status == 'completed').length / valid.length) * 100;
+}
+
+bool _projectIsOverdue(Project p, DateTime now) {
+  if (p.endDate == null || p.status == 'completed' || p.status == 'canceled') return false;
+  return DateTime.parse(p.endDate!).isBefore(now);
+}
+
+void main() {
+  group('Módulo financeiro (mínimo)', () {
+    test('criar receita e despesa, editar e excluir movimentação', () {
+      final store = _FinanceStore();
+      final income = store.create(title: 'Salário', amount: 3000, type: 'income', transactionDate: '2026-04-01');
+      final expense = store.create(title: 'Aluguel', amount: 1000, type: 'expense', transactionDate: '2026-04-02');
+
+      expect(store.items.length, 2);
+      expect(income.type, 'income');
+      expect(expense.type, 'expense');
+
+      store.update(expense.copyWith(amount: 1200));
+      expect(store.items.firstWhere((e) => e.id == expense.id).amount, 1200);
+
+      store.delete(income.id!);
+      expect(store.items.length, 1);
+    });
+
+    test('calcular receitas/despesas/saldo previsto e realizado', () {
+      final items = <FinancialTransaction>[
+        FinancialTransaction(
+          id: 1,
+          title: 'Salário',
+          amount: 4000,
+          type: 'income',
+          transactionDate: '2026-04-05',
+          status: 'paid',
+          isFixed: false,
+          recurrenceType: 'none',
+          createdAt: '2026-04-05',
+          updatedAt: '2026-04-05',
+        ),
+        FinancialTransaction(
+          id: 2,
+          title: 'Freela',
+          amount: 1000,
+          type: 'income',
+          transactionDate: '2026-04-10',
+          status: 'pending',
+          isFixed: false,
+          recurrenceType: 'none',
+          createdAt: '2026-04-10',
+          updatedAt: '2026-04-10',
+        ),
+        FinancialTransaction(
+          id: 3,
+          title: 'Mercado',
+          amount: 700,
+          type: 'expense',
+          transactionDate: '2026-04-12',
+          status: 'paid',
+          isFixed: false,
+          recurrenceType: 'none',
+          createdAt: '2026-04-12',
+          updatedAt: '2026-04-12',
+        ),
+        FinancialTransaction(
+          id: 4,
+          title: 'Academia',
+          amount: 100,
+          type: 'expense',
+          transactionDate: '2026-04-15',
+          status: 'pending',
+          isFixed: false,
+          recurrenceType: 'none',
+          createdAt: '2026-04-15',
+          updatedAt: '2026-04-15',
+        ),
+      ];
+
+      final ref = DateTime(2026, 4, 20);
+      expect(_receitasMes(items, ref), 5000);
+      expect(_despesasMes(items, ref), 800);
+      expect(_saldoPrevisto(items, ref), 4200);
+      expect(_saldoRealizado(items, ref), 3300);
+    });
+
+    test('marcar despesa como paga e identificar vencida', () {
+      final now = DateTime(2026, 4, 20);
+      final overdue = FinancialTransaction(
+        id: 1,
+        title: 'Conta de luz',
+        amount: 200,
+        type: 'expense',
+        transactionDate: '2026-04-01',
+        dueDate: '2026-04-10',
+        status: 'pending',
+        isFixed: false,
+        recurrenceType: 'none',
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      expect(_isOverdueExpense(overdue, now), isTrue);
+
+      final paid = overdue.copyWith(status: 'paid');
+      expect(_isOverdueExpense(paid, now), isFalse);
+    });
+  });
+
+  group('Módulo dívidas (mínimo)', () {
+    test('criar dívida e gerar parcelas automaticamente', () {
+      final debt = Debt(
+        id: 10,
+        name: 'Cartão',
+        totalAmount: 1200,
+        installmentAmount: 400,
+        installmentCount: 3,
+        status: 'active',
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      final installments = _generateInstallments(
+        debtId: debt.id!,
+        count: debt.installmentCount!,
+        amount: debt.installmentAmount!,
+        firstDueDate: DateTime(2026, 4, 10),
+      );
+      expect(installments.length, 3);
+      expect(installments.first.debtId, debt.id);
+      expect(installments.first.installmentNumber, 1);
+    });
+
+    test('marcar parcela paga, atualizar progresso, calcular restante e quitar dívida', () {
+      final debt = Debt(
+        id: 10,
+        name: 'Notebook',
+        totalAmount: 1000,
+        installmentAmount: 500,
+        installmentCount: 2,
+        status: 'active',
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      var installments = _generateInstallments(
+        debtId: debt.id!,
+        count: 2,
+        amount: 500,
+        firstDueDate: DateTime(2026, 4, 5),
+      );
+
+      installments = [
+        installments[0].copyWith(status: 'paid'),
+        installments[1],
+      ];
+      expect(_remainingDebt(debt, installments), 500);
+      expect(_progressDebt(debt, installments), 50);
+
+      installments = [
+        installments[0],
+        installments[1].copyWith(status: 'paid'),
+      ];
+      expect(_remainingDebt(debt, installments), 0);
+
+      final debtPaid = debt.copyWith(status: _remainingDebt(debt, installments) == 0 ? 'paid' : 'active');
+      expect(debtPaid.status, 'paid');
+    });
+
+    test('identificar parcela atrasada e manter transação financeira ao pagar parcela', () {
+      final now = DateTime(2026, 4, 20);
+      final installment = FinancialTransaction(
+        id: 1,
+        title: 'Parcela 1/3',
+        amount: 300,
+        type: 'expense',
+        transactionDate: '2026-04-01',
+        dueDate: '2026-04-10',
+        debtId: 999,
+        installmentNumber: 1,
+        totalInstallments: 3,
+        status: 'pending',
+        isFixed: false,
+        recurrenceType: 'none',
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      expect(_installmentIsOverdue(installment, now), isTrue);
+
+      final paidTx = installment.copyWith(status: 'paid');
+      expect(paidTx.type, 'expense');
+      expect(paidTx.debtId, 999);
+    });
+  });
+
+  group('Módulo projetos (mínimo)', () {
+    test('criar projeto, criar etapa e criar tarefa vinculada', () {
+      final project = Project(
+        id: 50,
+        name: 'Lançar MVP',
+        status: 'active',
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      final step = ProjectStep(
+        id: 7,
+        projectId: project.id!,
+        title: 'Planejamento',
+        orderIndex: 1,
+        status: 'pending',
+        createdAt: '2026-04-02',
+        updatedAt: '2026-04-02',
+      );
+      final task = Task(
+        id: 99,
+        title: 'Definir escopo',
+        projectId: project.id,
+        projectStepId: step.id,
+        priority: 'media',
+        status: 'pendente',
+        reminderEnabled: false,
+        createdAt: '2026-04-02',
+        updatedAt: '2026-04-02',
+      );
+
+      expect(project.id, 50);
+      expect(step.projectId, project.id);
+      expect(task.projectStepId, step.id);
+    });
+
+    test('calcular progresso por tarefas e por etapas', () {
+      final tasks = [
+        Task(
+          id: 1,
+          title: 'T1',
+          projectId: 1,
+          priority: 'media',
+          status: 'concluida',
+          reminderEnabled: false,
+          createdAt: '2026-04-01',
+          updatedAt: '2026-04-01',
+        ),
+        Task(
+          id: 2,
+          title: 'T2',
+          projectId: 1,
+          priority: 'media',
+          status: 'pendente',
+          reminderEnabled: false,
+          createdAt: '2026-04-01',
+          updatedAt: '2026-04-01',
+        ),
+      ];
+      expect(_projectProgressByTasks(tasks), 50);
+
+      final steps = [
+        ProjectStep(
+          id: 1,
+          projectId: 1,
+          title: 'S1',
+          orderIndex: 1,
+          status: 'completed',
+          createdAt: '2026-04-01',
+          updatedAt: '2026-04-01',
+        ),
+        ProjectStep(
+          id: 2,
+          projectId: 1,
+          title: 'S2',
+          orderIndex: 2,
+          status: 'pending',
+          createdAt: '2026-04-01',
+          updatedAt: '2026-04-01',
+        ),
+      ];
+      expect(_projectProgressBySteps(steps), 50);
+    });
+
+    test('marcar projeto como concluído, identificar atraso e remover vínculo ao excluir projeto', () {
+      final project = Project(
+        id: 1,
+        name: 'Projeto X',
+        status: 'active',
+        endDate: '2026-04-10',
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      expect(_projectIsOverdue(project, DateTime(2026, 4, 20)), isTrue);
+
+      final completed = project.copyWith(status: 'completed', progress: 100);
+      expect(completed.status, 'completed');
+      expect(completed.progress, 100);
+
+      final linkedTask = Task(
+        id: 1,
+        title: 'Tarefa vinculada',
+        projectId: project.id,
+        projectStepId: 5,
+        priority: 'media',
+        status: 'pendente',
+        reminderEnabled: false,
+        createdAt: '2026-04-01',
+        updatedAt: '2026-04-01',
+      );
+      final unlinked = linkedTask.copyWith(clearProjectId: true, clearProjectStepId: true);
+      expect(unlinked.projectId, isNull);
+      expect(unlinked.projectStepId, isNull);
+    });
+  });
+
+  group('Testes gerais de estabilidade', () {
+    test('temas claro e escuro estão configurados', () {
+      expect(AppTheme.lightTheme.colorScheme.brightness.name, 'light');
+      expect(AppTheme.darkTheme.colorScheme.brightness.name, 'dark');
+    });
+
+    test('migração inclui proteção para dados antigos', () {
+      final dbHelperContent = File('lib/data/database/db_helper.dart').readAsStringSync();
+      expect(dbHelperContent.contains('if (oldVersion < 14)'), isTrue);
+      expect(dbHelperContent.contains('project_stages'), isTrue);
+      expect(dbHelperContent.contains('project_steps'), isTrue);
+    });
+
+    test('workflow de CI para APK existe', () {
+      final workflow = File('.github/workflows/build-apk.yml');
+      expect(workflow.existsSync(), isTrue);
+      final content = workflow.readAsStringSync();
+      expect(content.contains('flutter build apk'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation

- Introduce richer project management (projects, stages/steps) and tie tasks/steps to projects with progress calculation and local reminders. 
- Improve UX by expanding home dashboard, calendar events, project screens and settings for the new features. 
- Persist new concepts safely via a database migration to a new schema version and add automation to run tests in CI. 

### Description

- Database and models: bumped DB to `diasorganize_v14.db` and `version: 14` with migrations that add `projects`, `project_stages`, `project_steps`, new columns (project-related fields, `reminderEnabled`, `progress`, `notes`, etc.) and create/upgrade paths; added `Project`, `ProjectStep` models and updated `Task` and `FinancialTransaction` models to include project/step and reminder fields; added project-step CRUD to `DatabaseHelper` and methods to manage linked records. 
- App logic and providers: added `appSettingsProvider` for persisted settings, expanded `projectsProvider`, `projectStepsProvider`, `tasksProvider`, `transactionsProvider`, and `debtsProvider` to handle recalculation of progress, scheduling/cancelling reminders, clearing canceled items and syncing reminders using `NotificationService`; added helper id functions in `NotificationService` for stable notification ids. 
- UI and features: implemented `CalendarScreen` with aggregated events (tasks, transactions, debt installments, project deadlines/steps), revamped `HomeScreen` dashboard (finance/debts/projects/alerts cards), new `ProjectsScreen`, `ProjectDetailsScreen`, `CreateProjectScreen`, `ProjectStep` flows, enhanced debt creation (`CreateDebtScreen`) to optionally generate installments with reminders, transaction creation (`CreateTransactionScreen`) to enable reminders, and task creation (`CreateTaskScreen`) to link tasks to projects and steps. 
- Tooling, docs and CI: updated `pubspec.yaml` (`intl` bump), extended `README.md` with v2 features and CI instructions, added `.gitignore` entry for `node_modules`, added a unit test file `test/version2_stability_test.dart` that validates finance/debt/project/task behaviors and DB migration presence, and updated `.github/workflows/build-apk.yml` to run `flutter test` and renamed the uploaded artifact to `DiasOrganize-v2-debug-apk`.

### Testing

- Added unit tests in `test/version2_stability_test.dart` covering minimal finance, debts, projects and general stability assertions such as theme availability and DB migration presence, but these tests are newly added and were not executed in this rollout. 
- CI workflow `/.github/workflows/build-apk.yml` was updated to run `flutter test` as part of the pipeline and to upload the artifact `DiasOrganize-v2-debug-apk`. 
- No automated test run results are included in this change description (tests are configured to run in CI on next push or `workflow_dispatch`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5dc76e088328b38e029427d0a664)